### PR TITLE
Support: Use the org.jenkins-ci version of aws-java-sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ hs_err_pid*
 *.iml
 target
 work
+*.releaseBackup
+release.properties

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,6 @@
 
 Access credentials from AWS Secrets Manager in your Jenkins jobs.
 
-## Contents
-
 - [CI Build](https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Faws-secrets-manager-credentials-provider-plugin/)
 - [Issues](https://issues.jenkins-ci.org/issues/?jql=component+%3D+aws-secrets-manager-credentials-provider-plugin)
 
@@ -30,9 +28,7 @@ Settings:
 
 Install and configure the plugin.
 
-- **Jenkins:** Compile the plugin `.hpi` from source, and upload to your Jenkins server. (Please see the Development instructions below.)
-- **Jenkins Evergreen:** Install this plugin on your Jenkins Evergreen server in the usual way. (This plugin is published to the Jenkins Incrementals repository). 
-
+Official plugin builds are not yet available, so you need to build the plugin `.hpi` from source, and upload it to your Jenkins server. Please see the Development instructions below.
 ### AWS IAM
 
 Give Jenkins an [IAM policy](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_identity-based-policies.html) with read access to AWS Secrets Manager.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 # AWS Secrets Manager Credentials Provider Plugin
 
 [![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/aws-secrets-manager-credentials-provider-plugin/master)](https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Faws-secrets-manager-credentials-provider-plugin/activity/)
+[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/aws-secrets-manager-credentials-provider.svg)](https://plugins.jenkins.io/aws-secrets-manager-credentials-provider)
 
 Access credentials from AWS Secrets Manager in your Jenkins jobs.
 
@@ -29,7 +30,8 @@ Settings:
 
 Install and configure the plugin.
 
-Official plugin builds are not yet available, so you need to build the plugin `.hpi` from source. Please see the Development instructions below.
+- **Jenkins:** Compile the plugin `.hpi` from source, and upload to your Jenkins server. (Please see the Development instructions below.)
+- **Jenkins Evergreen:** Install this plugin on your Jenkins Evergreen server in the usual way. (This plugin is published to the Jenkins Incrementals repository). 
 
 ### AWS IAM
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,14 @@
 
 [![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/aws-secrets-manager-credentials-provider-plugin/master)](https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Faws-secrets-manager-credentials-provider-plugin/activity/)
 
-Access credentials from AWS Secrets Manager in your Jenkins jobs. (Specify shared secrets once in your AWS account, use them from Jenkins.)
+Access credentials from AWS Secrets Manager in your Jenkins jobs.
 
-Features:
+## Contents
+
+- [CI Build](https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Faws-secrets-manager-credentials-provider-plugin/)
+- [Issues](https://issues.jenkins-ci.org/issues/?jql=component+%3D+aws-secrets-manager-credentials-provider-plugin)
+
+## Features
 
 - Read-only view of Secrets Manager.
 - Credential metadata caching (duration: 5 minutes).
@@ -116,9 +121,9 @@ unclassified:
 
 ### Dependencies
 
-- Java 8
-- [Docker](https://www.docker.com)
-- [Maven](https://maven.apache.org)
+- Docker
+- Java
+- Maven
 
 ### Build 
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <name>AWS Secrets Manager Credentials Provider</name>
     <description>Allows the Jenkins Credentials Store to look up secrets in AWS Secrets Manager.</description>
-    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <url>https://wiki.jenkins-ci.org/display/JENKINS/JIRA+Plugin</url>
     <inceptionYear>2019</inceptionYear>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,11 @@
         </developer>
     </developers>
 
+    <issueManagement>
+        <system>JIRA</system>
+        <url>https://issues.jenkins-ci.org/browse/JENKINS</url>
+    </issueManagement>
+
     <licenses>
         <license>
             <name>MIT License</name>
@@ -195,6 +200,12 @@
         <repository>
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
     </repositories>
 
@@ -202,6 +213,12 @@
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </pluginRepository>
     </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <name>AWS Secrets Manager Credentials Provider</name>
     <description>Allows the Jenkins Credentials Store to look up secrets in AWS Secrets Manager.</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/JIRA+Plugin</url>
+    <url>https://github.com/jenkinsci/aws-secrets-manager-credentials-provider-plugin</url>
     <inceptionYear>2019</inceptionYear>
 
     <developers>
@@ -39,9 +39,9 @@
     </licenses>
 
     <scm>
-        <connection>https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+        <connection>https://github.com/jenkinsci/aws-secrets-manager-credentials-provider-plugin.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/aws-secrets-manager-credentials-provider-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/aws-secrets-manager-credentials-provider-plugin</url>
         <tag>${scmTag}</tag>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <connection>https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+        <tag>${scmTag}</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <scm>
         <connection>https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
         <tag>${scmTag}</tag>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <name>AWS Secrets Manager Credentials Provider</name>
     <description>Allows the Jenkins Credentials Store to look up secrets in AWS Secrets Manager.</description>
-    <url>https://github.com/jenkinsci/aws-secrets-manager-credentials-provider-plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <inceptionYear>2019</inceptionYear>
 
     <developers>
@@ -39,9 +39,9 @@
     </licenses>
 
     <scm>
-        <connection>https://github.com/jenkinsci/aws-secrets-manager-credentials-provider-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/aws-secrets-manager-credentials-provider-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/aws-secrets-manager-credentials-provider-plugin</url>
+        <connection>https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
         <tag>${scmTag}</tag>
     </scm>
 
@@ -65,9 +65,9 @@
             <version>1.4</version>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-secretsmanager</artifactId>
-            <version>1.11.505</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>aws-java-sdk</artifactId>
+            <version>1.11.457</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -200,12 +200,6 @@
         <repository>
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
         </repository>
     </repositories>
 
@@ -213,12 +207,6 @@
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
         </pluginRepository>
     </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
     <scm>
         <connection>https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
         <tag>${scmTag}</tag>
     </scm>
 


### PR DESCRIPTION
Switch to the org.jenkins-ci version of aws-java-sdk. This is intended as a shared dependency for Jenkins plugins, so that we need not bundle a separate copy of the SDK in this plugin's `.hpi` artifact.