### PR TITLE
downgrade two dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,12 +67,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-credentials</artifactId>
-            <version>1.17.2</version>
+            <version>1.17.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.636</version>
+            <version>1.11.562</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Downgraded ssh-credentials and aws-java-sdk so the new features from 0.1.0 can be used with CloudBees Core 2.176.4.3