### PR TITLE
Obtain AWS configuration and SDK from aws-global-configuration plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,9 +70,9 @@
             <version>1.17.1</version>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.636</version>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>aws-global-configuration</artifactId>
+            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -116,6 +116,12 @@
             <scope>test</scope>
         </dependency>
         <!-- Workarounds -->
+        <dependency>
+            <!-- TODO remove when aws-global-configuration updates -->
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>aws-java-sdk</artifactId>
+            <version>1.11.636</version>
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>


### PR DESCRIPTION
Implements [JENKINS-60445](https://issues.jenkins-ci.org/browse/JENKINS-60445)

## Prerequisites

- [ ] Bump AWS SDK dependency version in aws-global-configuration plugin to `>= 1.11.636`.
- [ ] Add Endpoint Configuration property to aws-global-configuration plugin.

## Features

- [ ] Inherit AWS SDK dependency from aws-global-configuration plugin.
- [ ] Get AWS configuration from aws-global-configuration plugin:
  - [ ] Region
  - [ ] Access key
  - [ ] Endpoint Configuration

## Questions

- aws-global-configuration depends on aws-credentials to let users specify a bootstrapping AWS access key pair, if they can't (or won't) use IAM instance profiles. This plugin is a credentials provider. Any risk of load order clash?

## Notes

- aws-global-configuration can't provide configurations scoped for particular resources. Users MUST therefore configure Jenkins to authenticate with a single primary AWS account, and then use cross-account roles (implemented per-plugin) if they want Jenkins to access things in other AWS accounts (e.g. dev, qa, production).
- Further to the previous point, we would have to ensure the Jenkins ACL plugins are up to scratch, to let users restrict access to these environment-specific resources.