### PR TITLE
Fix: Degrade gracefully when Secrets Manager is unavailable

### DIFF
--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/CredentialsProviderIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/CredentialsProviderIT.java
@@ -36,6 +36,16 @@ public class CredentialsProviderIT extends AbstractPluginIT {
     }
 
     @Test
+    @ConfiguredWithCode(value = "/default.yml")
+    public void shouldFailGracefullyWhenSecretsManagerUnavailable() {
+        // When
+        final List<StringCredentials> credentials = lookupCredentials(StringCredentials.class);
+
+        // Then
+        assertThat(credentials).isEmpty();
+    }
+
+    @Test
     @ConfiguredWithCode(value = "/integration.yml")
     public void shouldUseSecretNameAsCredentialName() {
         // Given

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/CheckConnectionWebIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/CheckConnectionWebIT.java
@@ -1,19 +1,16 @@
 package io.jenkins.plugins.credentials.secretsmanager.config;
 
+import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 import com.gargoylesoftware.htmlunit.html.DomNode;
 import com.gargoylesoftware.htmlunit.html.HtmlButton;
 import com.gargoylesoftware.htmlunit.html.HtmlElement;
-
-import org.junit.Ignore;
+import io.jenkins.plugins.credentials.secretsmanager.util.JenkinsConfiguredWithWebRule;
 import org.junit.Rule;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import io.jenkins.plugins.credentials.secretsmanager.util.JenkinsConfiguredWithWebRule;
-
-@Ignore("pipeline-model-definition breaks the Web config UI with a load order bug between credentials consumers and (remote) providers")
 public class CheckConnectionWebIT extends AbstractCheckConnectionIT {
 
     @Rule
@@ -35,10 +32,12 @@ public class CheckConnectionWebIT extends AbstractCheckConnectionIT {
                 throw new RuntimeException(e);
             }
 
-            final HtmlElement successElement = form.getOneHtmlElementByAttribute("div", "class", "ok");
-            if (successElement != null) {
+            try {
+                final HtmlElement successElement = form.getOneHtmlElementByAttribute("div", "class", "ok");
                 result.set(Result.success(successElement.getTextContent()));
                 return;
+            } catch (ElementNotFoundException ignored) {
+                // Carry on
             }
 
             final HtmlElement failureElement = form.getOneHtmlElementByAttribute("div", "class", "error");

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/PluginWebConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/PluginWebConfigurationTest.java
@@ -1,14 +1,11 @@
 package io.jenkins.plugins.credentials.secretsmanager.config;
 
-import org.junit.Ignore;
+import io.jenkins.plugins.credentials.secretsmanager.util.JenkinsConfiguredWithWebRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-import io.jenkins.plugins.credentials.secretsmanager.util.JenkinsConfiguredWithWebRule;
-
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
-@Ignore("pipeline-model-definition breaks the Web config UI with a load order bug between credentials consumers and (remote) providers")
 public class PluginWebConfigurationTest extends AbstractPluginConfigurationTest {
 
     @Rule


### PR DESCRIPTION
Fixes [JENKINS-60652](https://issues.jenkins-ci.org/browse/JENKINS-60652) and [JENKINS-60791](https://issues.jenkins-ci.org/browse/JENKINS-60791)

Do not throw an exception when Secrets Manager is unavailable or cannot be contacted. Instead, return an (uncached) empty list of credentials.

This should:

- Allow credential list views to degrade gracefully.
- Avoid breaking builds that only use other credential providers.
- Allow the plugin to co-exist quietly on a Jenkins installation before it is configured.