### PR TITLE
Fix: Use distinct credential type icons

### DIFF
--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/certificate/AwsCertificateCredentials.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/certificate/AwsCertificateCredentials.java
@@ -63,5 +63,10 @@ public class AwsCertificateCredentials extends BaseStandardCredentials implement
         public String getDisplayName() {
             return Messages.certificate();
         }
+
+        @Override
+        public String getIconClassName() {
+            return "icon-credentials-certificate";
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/ssh_user_private_key/AwsSshUserPrivateKey.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/ssh_user_private_key/AwsSshUserPrivateKey.java
@@ -56,5 +56,10 @@ public class AwsSshUserPrivateKey extends BaseStandardCredentials implements SSH
         public String getDisplayName() {
             return Messages.sshUserPrivateKey();
         }
+
+        @Override
+        public String getIconClassName() {
+            return "icon-ssh-credentials-ssh-key";
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/username_password/AwsUsernamePasswordCredentials.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/username_password/AwsUsernamePasswordCredentials.java
@@ -41,5 +41,10 @@ public class AwsUsernamePasswordCredentials extends BaseStandardCredentials impl
         public String getDisplayName() {
             return Messages.usernamePassword();
         }
+
+        @Override
+        public String getIconClassName() {
+            return "icon-credentials-userpass";
+        }
     }
 }

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/CredentialsTests.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/CredentialsTests.java
@@ -7,6 +7,9 @@ public interface CredentialsTests {
     void shouldHaveName();
 
     @Test
+    void shouldHaveIcon();
+
+    @Test
     void shouldAppearInCredentialsProvider();
 
     @Test

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/SSHUserPrivateKeyIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/SSHUserPrivateKeyIT.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.credentials.secretsmanager;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
@@ -119,5 +120,17 @@ public class SSHUserPrivateKeyIT extends AbstractPluginIT implements Credentials
         assertThat(after)
                 .extracting("id", "username", "privateKey", "passphrase")
                 .containsOnly(foo.getName(), USERNAME, PRIVATE_KEY, EMPTY_PASSPHRASE);
+    }
+
+    @Test
+    @ConfiguredWithCode(value = "/integration.yml")
+    public void shouldHaveIcon() {
+        final CreateSecretOperation.Result foo = createSshUserPrivateKeySecret(USERNAME, PRIVATE_KEY);
+        final SSHUserPrivateKey ours = lookupCredential(SSHUserPrivateKey.class, foo.getName());
+
+        final BasicSSHUserPrivateKey theirs = new BasicSSHUserPrivateKey(null, "id", "username", null, "passphrase", "description");
+
+        assertThat(ours.getDescriptor().getIconClassName())
+                .isEqualTo(theirs.getDescriptor().getIconClassName());
     }
 }

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/StandardCertificateCredentialsIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/StandardCertificateCredentialsIT.java
@@ -1,8 +1,10 @@
 package io.jenkins.plugins.credentials.secretsmanager;
 
 import com.cloudbees.plugins.credentials.CredentialsUnavailableException;
+import com.cloudbees.plugins.credentials.SecretBytes;
 import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
 
+import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -54,6 +56,19 @@ public class StandardCertificateCredentialsIT extends AbstractPluginIT implement
         assertThat(list)
                 .extracting("name", "value")
                 .containsOnly(tuple(CN, foo.getName()));
+    }
+
+    @Test
+    @ConfiguredWithCode(value = "/integration.yml")
+    public void shouldHaveIcon() {
+        final byte[] keystore = Crypto.save(Crypto.singletonKeyStore(ALIAS, KEY_PAIR.getPrivate(), PASSWORD, new Certificate[]{CERT}), PASSWORD);
+        final CreateSecretOperation.Result foo = createCertificateSecret(keystore);
+        final StandardCertificateCredentials ours = lookupCredential(StandardCertificateCredentials.class, foo.getName());
+
+        final StandardCertificateCredentials theirs = new CertificateCredentialsImpl(null, "id", "description", "password", new CertificateCredentialsImpl.UploadedKeyStoreSource(SecretBytes.fromBytes(keystore)));
+
+        assertThat(ours.getDescriptor().getIconClassName())
+                .isEqualTo(theirs.getDescriptor().getIconClassName());
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/StandardUsernamePasswordCredentialsIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/StandardUsernamePasswordCredentialsIT.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.credentials.secretsmanager;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
@@ -116,5 +117,17 @@ public class StandardUsernamePasswordCredentialsIT extends AbstractPluginIT impl
         assertThat(after)
                 .extracting("id", "username", "password")
                 .containsOnly(foo.getName(), USERNAME, Secret.fromString(PASSWORD));
+    }
+
+    @Test
+    @ConfiguredWithCode(value = "/integration.yml")
+    public void shouldHaveIcon() {
+        final CreateSecretOperation.Result foo = createUsernamePasswordSecret(USERNAME, PASSWORD);
+        final StandardUsernamePasswordCredentials ours = lookupCredential(StandardUsernamePasswordCredentials.class, foo.getName());
+
+        final StandardUsernamePasswordCredentials theirs = new UsernamePasswordCredentialsImpl(null, "id", "description", "username", "password");
+
+        assertThat(ours.getDescriptor().getIconClassName())
+                .isEqualTo(theirs.getDescriptor().getIconClassName() + "a");
     }
 }

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/StandardUsernamePasswordCredentialsIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/StandardUsernamePasswordCredentialsIT.java
@@ -128,6 +128,6 @@ public class StandardUsernamePasswordCredentialsIT extends AbstractPluginIT impl
         final StandardUsernamePasswordCredentials theirs = new UsernamePasswordCredentialsImpl(null, "id", "description", "username", "password");
 
         assertThat(ours.getDescriptor().getIconClassName())
-                .isEqualTo(theirs.getDescriptor().getIconClassName() + "a");
+                .isEqualTo(theirs.getDescriptor().getIconClassName());
     }
 }

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/StringCredentialsIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/StringCredentialsIT.java
@@ -6,6 +6,7 @@ import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.credentials.secretsmanager.util.CreateSecretOperation;
 import io.jenkins.plugins.credentials.secretsmanager.util.Strings;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.junit.Test;
 
 import java.util.List;
@@ -111,5 +112,17 @@ public class StringCredentialsIT extends AbstractPluginIT implements Credentials
         assertThat(after)
                 .extracting("id", "secret")
                 .containsOnly(foo.getName(), Secret.fromString("supersecret"));
+    }
+
+    @Test
+    @ConfiguredWithCode(value = "/integration.yml")
+    public void shouldHaveIcon() {
+        final CreateSecretOperation.Result foo = createStringSecret("supersecret");
+        final StringCredentials ours = lookupCredential(StringCredentials.class, foo.getName());
+
+        final StringCredentials theirs = new StringCredentialsImpl(null, "id", "description", Secret.fromString("secret"));
+
+        assertThat(ours.getDescriptor().getIconClassName())
+                .isEqualTo(theirs.getDescriptor().getIconClassName());
     }
 }


### PR DESCRIPTION
Fixes [JENKINS-60692](https://issues.jenkins-ci.org/browse/JENKINS-60692)