### PR TITLE
Feature: Multi-account secrets access

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Access credentials from AWS Secrets Manager in your Jenkins jobs.
 ## Contents
 
 - [Authentication](authentication/index.md)
+- [Beta Features](beta/index.md)
 - [Caching](caching/index.md)
 - [Filters](filters/index.md)
 - [Networking](networking/index.md)
@@ -22,7 +23,6 @@ Access credentials from AWS Secrets Manager in your Jenkins jobs.
 - Read-only view of Secrets Manager.
 - `CredentialsProvider` and `SecretSource` API support.
 - Credential metadata caching (duration: 5 minutes).
-- [Cross-account](http://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) Secrets Manager support with IAM roles.
  
 ## Setup 
 
@@ -356,4 +356,3 @@ In your IDE:
 3. Start Moto: `mvn docker:build docker:start`.
 4. Run tests.
 5. Stop Moto: `mvn docker:stop`.
-

--- a/docs/beta/index.md
+++ b/docs/beta/index.md
@@ -1,0 +1,19 @@
+# Beta
+
+The plugin contains the following beta features:
+
+- [Secondary IAM Roles](roles/index.md)
+
+## Warnings
+
+- Beta features are not officially supported.
+- Beta features may be added, changed, or removed without warning.
+- Beta features may break Jenkins.
+- Beta feature configuration must be manually updated when the config schema changes.
+
+## Recommendations
+
+- Test beta features on a non-production Jenkins.
+- Read the plugin release notes before upgrading.
+- Use Jenkins Configuration As Code (CasC). (CasC can warn you when the configuration schema changes.)
+- Report bugs and feedback on the Jenkins issue tracker.

--- a/docs/beta/roles/index.md
+++ b/docs/beta/roles/index.md
@@ -2,9 +2,9 @@
 
 The plugin can access more secrets using secondary IAM roles.
 
-The most common use case is to access secrets in other accounts using [cross-account roles](http://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html). In this setup, Jenkins accesses secrets in its own account using its implicit primary role, and is assigned a secondary role for each other account that it should read secrets from.
+The most common use case is to access secrets in other accounts using [cross-account roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html). In this setup, Jenkins accesses secrets in its own account using its (implicit) primary role, and is assigned a secondary role for each other account that it should read secrets from.
 
-Secrets in different accounts may have the same name. To allow them to co-exist, credentials from primary and secondary roles (accounts) use different secret attributes for their identifiers:
+Secrets in different accounts may have the same name. To allow them to co-exist within Jenkins, credentials from primary and secondary roles use different secret attributes for their IDs:
 
 <table>
     <thead>

--- a/docs/beta/roles/index.md
+++ b/docs/beta/roles/index.md
@@ -1,0 +1,51 @@
+## Roles
+
+The plugin can access more secrets using secondary IAM roles.
+
+The most common use case is to access secrets in other accounts using [cross-account roles](http://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html). In this setup, Jenkins accesses secrets in its own account using its implicit primary role, and is assigned a secondary role for each other account that it should read secrets from.
+
+Secrets in different accounts may have the same name. To allow them to co-exist, credentials from primary and secondary roles (accounts) use different secret attributes for their identifiers:
+
+<table>
+    <thead>
+        <tr>
+            <td>Role</td>
+            <td>Credential ID</td>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Primary</td>
+            <td>Secret Name</td>
+        </tr>
+        <tr>
+            <td>Secondary</td>
+            <td>Secret ARN</td>
+        </tr>
+    </tbody>
+</table>
+
+## Setup
+
+For each secondary role:
+
+1. Create the role and associated policies in AWS.
+2. Test that Jenkins can assume the role and retrieve secrets.
+3. Add the role ARN to the `roles` list in the plugin configuration.
+
+```yaml
+unclassified:
+  awsCredentialsProvider:
+    beta:
+      roles:
+        - arn:aws:iam::111111111111:role/foo
+        - arn:aws:iam::222222222222:role/bar
+```
+
+## Considerations
+
+**Do not add more roles than necessary.** Each additional role necessitates another set of HTTP requests to retrieve secrets. This increases the time to populate the credential list. It also increases the risk of service degradation, as any of those requests could fail.
+
+## Limitations
+
+The primary role cannot currently be turned off. This might be a problem if you use the primary role to access a gateway account, and the secondary roles to access your 'real' accounts, and don't want Jenkins to use Secrets Manager in the gateway account.

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/AssumeRoleDefaults.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/AssumeRoleDefaults.java
@@ -1,0 +1,11 @@
+package io.jenkins.plugins.credentials.secretsmanager;
+
+public abstract class AssumeRoleDefaults {
+
+    public static final int SESSION_DURATION_SECONDS = 900;
+    public static final String SESSION_NAME = "io.jenkins.plugins.aws-secrets-manager-credentials-provider";
+
+    private AssumeRoleDefaults() {
+
+    }
+}

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/ARN.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/ARN.java
@@ -1,0 +1,46 @@
+package io.jenkins.plugins.credentials.secretsmanager.config;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import io.jenkins.plugins.credentials.secretsmanager.Messages;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+
+public class ARN extends AbstractDescribableImpl<ARN> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String value;
+
+    @DataBoundConstructor
+    public ARN(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @DataBoundSetter
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Extension
+    @Symbol("arn")
+    @SuppressWarnings("unused")
+    public static class DescriptorImpl extends Descriptor<ARN> {
+
+        @Override
+        @Nonnull
+        public String getDisplayName() {
+            return Messages.arn();
+        }
+
+    }
+}

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Beta.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Beta.java
@@ -1,0 +1,50 @@
+package io.jenkins.plugins.credentials.secretsmanager.config;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import io.jenkins.plugins.credentials.secretsmanager.Messages;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+
+/**
+ * Configuration for beta features.
+ */
+public class Beta extends AbstractDescribableImpl<Beta> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The IAM role ARNs to assume. For multi-account secrets retrieval.
+     */
+    private Roles roles;
+
+    @DataBoundConstructor
+    public Beta(Roles roles) {
+        this.roles = roles;
+    }
+
+    public Roles getRoles() {
+        return roles;
+    }
+
+    @DataBoundSetter
+    public void setRoles(Roles roles) {
+        this.roles = roles;
+    }
+
+    @Extension
+    @Symbol("beta")
+    @SuppressWarnings("unused")
+    public static class DescriptorImpl extends Descriptor<Beta> {
+        @Override
+        @Nonnull
+        public String getDisplayName() {
+            return Messages.beta();
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/BetaConfigurator.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/BetaConfigurator.java
@@ -1,0 +1,69 @@
+package io.jenkins.plugins.credentials.secretsmanager.config;
+
+import com.google.common.collect.Sets;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import io.jenkins.plugins.casc.*;
+import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Extension(optional = true, ordinal = 2)
+@Restricted(NoExternalUse.class)
+@SuppressWarnings("unused")
+public class BetaConfigurator extends BaseConfigurator<Beta>
+        implements Configurator<Beta> {
+
+    // NOTE: this MUST be the same as the target class' @Symbol annotation
+    @Override
+    @NonNull
+    public String getName() {
+        return "beta";
+    }
+
+    @Override
+    public Class<Beta> getTarget() {
+        return Beta.class;
+    }
+
+    @Override
+    public Beta instance(Mapping mapping, ConfigurationContext context) {
+        final PluginConfiguration config = PluginConfiguration.all().get(PluginConfiguration.class);
+
+        if (config == null || config.getBeta() == null) {
+            // avoid NPE
+            return new Beta(null);
+        }
+
+        return config.getBeta();
+    }
+
+    @Override
+    @NonNull
+    public Set<Attribute<Beta,?>> describe() {
+        return Sets.newHashSet(
+                new MultivaluedAttribute<Beta, String>("roles", String.class)
+                        .setter((target, roleArns) -> {
+                            final List<ARN> arns = roleArns.stream().map(ARN::new).collect(Collectors.toList());
+                            target.setRoles(new Roles(arns));
+                        }));
+    }
+
+    @CheckForNull
+    @Override
+    public CNode describe(Beta instance, ConfigurationContext context) throws Exception {
+        Mapping mapping = new Mapping();
+        for (Attribute<Beta, ?> attribute : describe()) {
+            mapping.put(attribute.getName(), attribute.describe(instance, context));
+        }
+        return mapping;
+    }
+
+}

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/EndpointConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/EndpointConfiguration.java
@@ -73,7 +73,7 @@ public class EndpointConfiguration extends AbstractDescribableImpl<EndpointConfi
         }
 
         /**
-         * Test the connection to AWS Secrets Manager.
+         * Test the endpoint configuration.
          *
          * @param serviceEndpoint the AWS service endpoint e.g. http://localhost:4584
          * @param signingRegion the AWS signing region e.g. us-east-1
@@ -81,7 +81,7 @@ public class EndpointConfiguration extends AbstractDescribableImpl<EndpointConfi
          */
         @POST
         @SuppressWarnings("unused")
-        public FormValidation doTestConnection(
+        public FormValidation doTestEndpointConfiguration(
                 @QueryParameter("serviceEndpoint") final String serviceEndpoint,
                 @QueryParameter("signingRegion") final String signingRegion) {
             Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/PluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/PluginConfiguration.java
@@ -1,17 +1,17 @@
 package io.jenkins.plugins.credentials.secretsmanager.config;
 
+import hudson.Extension;
+import jenkins.model.GlobalConfiguration;
 import net.sf.json.JSONObject;
-
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
-import hudson.Extension;
-import jenkins.model.GlobalConfiguration;
-
 @Extension
 @Symbol("awsCredentialsProvider")
 public class PluginConfiguration extends GlobalConfiguration {
+
+    private Beta beta;
 
     /**
      * The AWS Secrets Manager endpoint configuration. If this is null, the default will be used. If
@@ -27,6 +27,17 @@ public class PluginConfiguration extends GlobalConfiguration {
 
     public static PluginConfiguration getInstance() {
         return all().get(PluginConfiguration.class);
+    }
+
+    public Beta getBeta() {
+        return beta;
+    }
+
+    @DataBoundSetter
+    @SuppressWarnings("unused")
+    public void setBeta(Beta beta) {
+        this.beta = beta;
+        save();
     }
 
     public EndpointConfiguration getEndpointConfiguration() {
@@ -56,6 +67,7 @@ public class PluginConfiguration extends GlobalConfiguration {
         // This method is unnecessary, except to apply the following workaround.
         // Workaround: Set any optional struct fields to null before binding configuration.
         // https://groups.google.com/forum/#!msg/jenkinsci-dev/MuRJ-yPRRoo/AvoPZAgbAAAJ
+        this.beta = null;
         this.endpointConfiguration = null;
         this.filters = null;
 

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Roles.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Roles.java
@@ -1,0 +1,46 @@
+package io.jenkins.plugins.credentials.secretsmanager.config;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import io.jenkins.plugins.credentials.secretsmanager.Messages;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.util.List;
+
+public class Roles extends AbstractDescribableImpl<Roles> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private List<ARN> arns;
+
+    @DataBoundConstructor
+    public Roles(List<ARN> arns) {
+        this.arns = arns;
+    }
+
+    public List<ARN> getArns() {
+        return arns;
+    }
+
+    @DataBoundSetter
+    public void setArns(List<ARN> arns) {
+        this.arns = arns;
+    }
+
+    @Extension
+    @Symbol("roles")
+    @SuppressWarnings("unused")
+    public static class DescriptorImpl extends Descriptor<Roles> {
+
+        @Override
+        @Nonnull
+        public String getDisplayName() {
+            return Messages.roles();
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/supplier/CredentialsSupplier.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/supplier/CredentialsSupplier.java
@@ -1,0 +1,145 @@
+package io.jenkins.plugins.credentials.secretsmanager.supplier;
+
+import com.amazonaws.SdkBaseException;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import com.amazonaws.services.secretsmanager.model.SecretListEntry;
+import com.amazonaws.services.secretsmanager.model.Tag;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import io.jenkins.plugins.credentials.secretsmanager.AssumeRoleDefaults;
+import io.jenkins.plugins.credentials.secretsmanager.config.*;
+import io.jenkins.plugins.credentials.secretsmanager.factory.CredentialsFactory;
+
+import java.util.*;
+import java.util.concurrent.CompletionException;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+public class CredentialsSupplier implements Supplier<Collection<StandardCredentials>> {
+
+    private static final Logger LOG = Logger.getLogger(CredentialsSupplier.class.getName());
+
+    private CredentialsSupplier() {
+
+    }
+
+    public static Supplier<Collection<StandardCredentials>> standard() {
+        return new CredentialsSupplier();
+    }
+
+    @Override
+    public Collection<StandardCredentials> get() {
+        LOG.log(Level.FINE,"Retrieve secrets from AWS Secrets Manager");
+
+        final PluginConfiguration config = PluginConfiguration.getInstance();
+
+        final EndpointConfiguration ec = config.getEndpointConfiguration();
+        final AwsClientBuilder.EndpointConfiguration endpointConfiguration = newEndpointConfiguration(ec);
+
+        final Filters filters = config.getFilters();
+        final Predicate<SecretListEntry> secretFilter = newSecretFilter(filters);
+
+        final Roles roles = Optional.ofNullable(config.getBeta()).map(beta -> beta.getRoles()).orElse(null);
+        final List<String> roleArns = newRoleArns(roles);
+
+        final Supplier<Collection<StandardCredentials>> mainSupplier =
+                new SingleAccountCredentialsSupplier(newClient(endpointConfiguration), SecretListEntry::getName, secretFilter);
+
+        final Collection<Supplier<Collection<StandardCredentials>>> otherSuppliers = roleArns.stream()
+                .map(roleArn -> new SingleAccountCredentialsSupplier(newClient(roleArn, endpointConfiguration), SecretListEntry::getARN, secretFilter))
+                .collect(Collectors.toList());
+
+        final ParallelSupplier<Collection<StandardCredentials>> allSuppliers = new ParallelSupplier<>(Lists.concat(mainSupplier, otherSuppliers));
+
+        try {
+            return allSuppliers.get()
+                    .stream()
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toMap(StandardCredentials::getId, Function.identity()))
+                    .values();
+        } catch (CompletionException | IllegalStateException e) {
+            // Re-throw in a way that the provider knows how to catch
+            throw new SdkBaseException(e.getCause());
+        }
+    }
+
+    private static Predicate<SecretListEntry> newSecretFilter(Filters filters) {
+        if (filters != null && filters.getTag() != null) {
+            final com.amazonaws.services.secretsmanager.model.Tag filterTag = new Tag()
+                    .withKey(filters.getTag().getKey())
+                    .withValue(filters.getTag().getValue());
+            return s -> Optional.ofNullable(s.getTags()).orElse(Collections.emptyList()).contains(filterTag);
+        } else {
+            return s -> true;
+        }
+    }
+
+    private static AWSSecretsManager newClient(AwsClientBuilder.EndpointConfiguration endpointConfiguration) {
+        return AWSSecretsManagerClientBuilder.standard()
+                .withEndpointConfiguration(endpointConfiguration)
+                .build();
+    }
+
+    private static AWSSecretsManager newClient(String roleArn, AwsClientBuilder.EndpointConfiguration endpointConfiguration) {
+        final AWSCredentialsProvider roleCredentials = new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, AssumeRoleDefaults.SESSION_NAME)
+                .withRoleSessionDurationSeconds(AssumeRoleDefaults.SESSION_DURATION_SECONDS)
+                .build();
+
+        return AWSSecretsManagerClientBuilder.standard()
+                .withEndpointConfiguration(endpointConfiguration)
+                .withCredentials(roleCredentials)
+                .build();
+    }
+
+    private static List<String> newRoleArns(Roles roles) {
+        if (roles != null && roles.getArns() != null) {
+            return roles.getArns().stream().map(ARN::getValue).collect(Collectors.toList());
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    private static AwsClientBuilder.EndpointConfiguration newEndpointConfiguration(EndpointConfiguration ec) {
+        if (ec == null || (ec.getServiceEndpoint() == null || ec.getSigningRegion() == null)) {
+            return null;
+        } else {
+            return new AwsClientBuilder.EndpointConfiguration(ec.getServiceEndpoint(), ec.getSigningRegion());
+        }
+    }
+
+    private static class SingleAccountCredentialsSupplier implements Supplier<Collection<StandardCredentials>> {
+
+        private final AWSSecretsManager client;
+        private final Function<SecretListEntry, String> nameSelector;
+        private final Predicate<SecretListEntry> secretFilter;
+
+        SingleAccountCredentialsSupplier(AWSSecretsManager client, Function<SecretListEntry, String> nameSelector, Predicate<SecretListEntry> secretFilter) {
+            this.client = client;
+            this.nameSelector = nameSelector;
+            this.secretFilter = secretFilter;
+        }
+
+        @Override
+        public Collection<StandardCredentials> get() {
+            final Collection<SecretListEntry> secretList = new ListSecretsOperation(client).get();
+
+            return secretList.stream()
+                    .filter(secretFilter)
+                    .flatMap(secretListEntry -> {
+                        final String name = nameSelector.apply(secretListEntry);
+                        final String description = Optional.ofNullable(secretListEntry.getDescription()).orElse("");
+                        final Map<String, String> tags = Lists.toMap(secretListEntry.getTags(), Tag::getKey, Tag::getValue);
+                        final Optional<StandardCredentials> cred = CredentialsFactory.create(name, description, tags, client);
+                        return Optionals.stream(cred);
+                    })
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/supplier/ListSecretsOperation.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/supplier/ListSecretsOperation.java
@@ -1,4 +1,4 @@
-package io.jenkins.plugins.credentials.secretsmanager;
+package io.jenkins.plugins.credentials.secretsmanager.supplier;
 
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.model.ListSecretsRequest;

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/supplier/Lists.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/supplier/Lists.java
@@ -1,0 +1,25 @@
+package io.jenkins.plugins.credentials.secretsmanager.supplier;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+abstract class Lists {
+
+    private Lists() {
+
+    }
+
+    static <T> Collection<T> concat(T thing, Collection<T> things) {
+       final ArrayList<T> list = new ArrayList<>();
+       list.add(thing);
+       list.addAll(things);
+       return list;
+   }
+
+    static <T> Map<String, String> toMap(List<T> things, Function<? super T, ? extends String> keyMapper, Function<? super T, ? extends String> valueMapper) {
+        return Optional.ofNullable(things).orElse(Collections.emptyList()).stream()
+                .filter(tag -> (keyMapper.apply(tag) != null) && (valueMapper.apply(tag) != null))
+                .collect(Collectors.toMap(keyMapper, valueMapper));
+    }
+}

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/supplier/Optionals.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/supplier/Optionals.java
@@ -1,0 +1,21 @@
+package io.jenkins.plugins.credentials.secretsmanager.supplier;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+abstract class Optionals {
+    private Optionals() {
+
+    }
+
+    /**
+     * Polyfill for Java 9 Optional::stream.
+     *
+     * @param o the optional
+     * @param <T> the type
+     * @return the stream
+     */
+    static <T> Stream<T> stream(Optional<T> o) {
+        return o.map(Stream::of).orElse(Stream.empty());
+    }
+}

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/supplier/ParallelSupplier.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/supplier/ParallelSupplier.java
@@ -1,0 +1,46 @@
+package io.jenkins.plugins.credentials.secretsmanager.supplier;
+
+import java.util.Collection;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Run multiple synchronous suppliers in parallel, and collect their results in one big list.
+ */
+class ParallelSupplier<T> implements Supplier<Collection<T>> {
+
+    private final Collection<Supplier<T>> suppliers;
+
+    ParallelSupplier(Collection<Supplier<T>> suppliers) {
+        this.suppliers = suppliers;
+    }
+
+    /**
+     * Run the suppliers.
+     *
+     * @throws CancellationException if one of the suppliers' computations was cancelled
+     * @throws CompletionException if one of the suppliers' futures completed exceptionally or a completion computation
+     * threw an exception
+     */
+    @Override
+    public Collection<T> get() {
+        final Collection<CompletableFuture<T>> supplierFutures = suppliers.stream()
+                .map(CompletableFuture::supplyAsync)
+                .collect(Collectors.toList());
+
+        final CompletableFuture<Collection<T>> future = flip(supplierFutures);
+
+        return future.join();
+    }
+
+    /**
+     * Flip a Seq of Futures to a Future of Seq.
+     */
+    private static <T> CompletableFuture<Collection<T>> flip(Collection<CompletableFuture<T>> futures) {
+        final CompletableFuture<Void> allDoneFuture = CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[0]));
+        return allDoneFuture.thenApply(v -> futures.stream().map(CompletableFuture::join).collect(Collectors.toList()));
+    }
+}

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/Messages.properties
@@ -17,3 +17,7 @@ noUsernameError = Credential did not have a username
 noPrivateKeyError = Credential did not contain a valid private key in PEM format
 noCertificateError = Credential did not contain a valid certificate bundle in PKCS#12 format
 emptySecretError = AWS Secrets Manager entry {0} contained neither a secretString nor a secretBinary value
+roles = Roles
+role = Role
+arn = ARN
+beta = Beta

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/ARN/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/ARN/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="">
+        <f:textbox field="value" />
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Beta/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Beta/config.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:optionalProperty field="roles" title="${%roles}" />
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Beta/config_en.properties
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Beta/config_en.properties
@@ -1,0 +1,1 @@
+roles = IAM Cross-Account Roles

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Beta/config_en.properties
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Beta/config_en.properties
@@ -1,1 +1,1 @@
-roles = IAM Cross-Account Roles
+roles = Secondary IAM Roles

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Beta/help-roles.html
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Beta/help-roles.html
@@ -1,9 +1,32 @@
 <div>
-    <p>Enable access to credentials stored in other AWS accounts.</p>
-    <p>Setup:</p>
+    <p>The plugin can access more secrets using secondary IAM roles.</p>
+    <p>The most common use case is to access secrets in other accounts using <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html">cross-account roles</a>. In this setup, Jenkins accesses secrets in its own account using its (implicit) primary role, and is assigned a secondary role for each other account that it should read secrets from.</p>
+    <p>Secrets in different accounts may have the same name. To allow them to co-exist within Jenkins, credentials from primary and secondary roles use different secret attributes for their IDs:</p>
+    <table>
+        <thead>
+        <tr>
+            <td>Role</td>
+            <td>Credential ID</td>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>Primary</td>
+            <td>Secret Name</td>
+        </tr>
+        <tr>
+            <td>Secondary</td>
+            <td>Secret ARN</td>
+        </tr>
+        </tbody>
+    </table>
+    <h3>Setup</h3>
+    <p>For each secondary role:</p>
     <ol>
-        <li>Create the IAM cross-account role and associated policies in AWS.</li>
-        <li>Test that Jenkins can assume the role and retrieve secrets from the other account.</li>
+        <li>Create the role and associated policies in AWS.</li>
+        <li>Test that Jenkins can assume the role and retrieve secrets.</li>
         <li>Add the role's ARN to the list below.</li>
     </ol>
+    <h3>Considerations</h3>
+    <p><strong>Do not add more roles than necessary.</strong> Each additional role necessitates another set of HTTP requests to retrieve secrets. This increases the time to populate the credential list. It also increases the risk of service degradation, as any of those requests could fail.
 </div>

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Beta/help-roles.html
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Beta/help-roles.html
@@ -1,0 +1,9 @@
+<div>
+    <p>Enable access to credentials stored in other AWS accounts.</p>
+    <p>Setup:</p>
+    <ol>
+        <li>Create the IAM cross-account role and associated policies in AWS.</li>
+        <li>Test that Jenkins can assume the role and retrieve secrets from the other account.</li>
+        <li>Add the role's ARN to the list below.</li>
+    </ol>
+</div>

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/EndpointConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/EndpointConfiguration/config.jelly
@@ -7,8 +7,8 @@
         <f:textbox field="signingRegion" />
     </f:entry>
     <f:validateButton
-        title="${%testConnection}"
+        title="${%testEndpointConfiguration}"
         progress="${%testing}"
-        method="testConnection"
+        method="testEndpointConfiguration"
         with="serviceEndpoint,signingRegion" />
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/EndpointConfiguration/config_en.properties
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/EndpointConfiguration/config_en.properties
@@ -1,4 +1,4 @@
 serviceEndpoint=Service Endpoint
 signingRegion=Signing Region
-testConnection=Test Connection
+testEndpointConfiguration=Test Endpoint Configuration
 testing=Testing...

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/PluginConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/PluginConfiguration/config.jelly
@@ -1,6 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <f:section title="${%awsSecretsManagerCredentialsProvider}">
+        <f:optionalProperty field="beta" title="${%beta}" />
         <f:optionalProperty field="endpointConfiguration" title="${%endpointConfiguration}" />
         <f:optionalProperty field="filters" title="${%filters}" />
     </f:section>

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/PluginConfiguration/config_en.properties
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/PluginConfiguration/config_en.properties
@@ -1,3 +1,4 @@
 awsSecretsManagerCredentialsProvider=AWS Secrets Manager Credentials Provider
+beta = Beta Features
 endpointConfiguration=Endpoint Configuration
 filters=Filters

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/PluginConfiguration/help-beta.html
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/PluginConfiguration/help-beta.html
@@ -1,0 +1,16 @@
+<div>
+    <p>Enable experimental features.</p>
+    <p>Warnings:</p>
+    <ul>
+        <li><strong>No official support.</strong> Beta features are provided on a strictly best-effort basis.</li>
+        <li><strong>Unstable code.</strong> Beta features may be added, changed, or removed between releases, without warning.</li>
+        <li><strong>Unstable configuration.</strong> Beta feature configuration may be changed between releases, without warning.</li>
+        <li><strong>Manual configuration updates required.</strong> Unlike regular features, you must update the configuration of beta features manually when their config schema changes.</li>
+    </ul>
+    <p>Recommendations:</p>
+    <ul>
+        <li><strong>Test on a non-production Jenkins.</strong> This will allow you see whether the beta feature will work in your environment.</li>
+        <li><strong>Read the plugin release notes.</Strong> Always read the release notes before upgrading the plugin, to check for beta feature changes.</li>
+        <li><strong>Use Jenkins Configuration As Code (CasC).</strong> CasC will reject configuration that contains outdated or deleted properties, and warn you about it.</li>
+    </ul>
+</div>

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Roles/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Roles/config.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="arns" title="${%arns}">
+        <f:repeatableProperty field="arns" minimum="1">
+            <f:entry title="">
+                <div align="right">
+                    <f:repeatableDeleteButton />
+                </div>
+            </f:entry>
+        </f:repeatableProperty>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Roles/config_en.properties
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Roles/config_en.properties
@@ -1,0 +1,1 @@
+arns=ARNs

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/RolesIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/RolesIT.java
@@ -1,0 +1,69 @@
+package io.jenkins.plugins.credentials.secretsmanager;
+
+import com.amazonaws.services.secretsmanager.model.CreateSecretRequest;
+import com.amazonaws.services.secretsmanager.model.CreateSecretResult;
+import com.amazonaws.services.secretsmanager.model.Tag;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.credentials.secretsmanager.factory.Type;
+import io.jenkins.plugins.credentials.secretsmanager.util.*;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+public class RolesIT {
+
+    public final MyJenkinsConfiguredWithCodeRule jenkins = new MyJenkinsConfiguredWithCodeRule();
+    public final AWSSecretsManagerRule secretsManager = new AutoErasingAWSSecretsManagerRule();
+
+    @Rule
+    public final RuleChain chain = RuleChain
+            .outerRule(Rules.awsAccessKey("fake", "fake"))
+            .around(jenkins)
+            .around(secretsManager);
+
+    @Ignore("Moto does not support cross-account operations")
+    public void shouldFetchCredentialsFromMultipleAccounts() {
+        fail("Implement this test");
+    }
+
+    @Ignore("Moto does not support cross-account operations")
+    public void shouldThrowExceptionWhenDuplicateSecretNamesPresent() {
+        fail("Implement this test");
+    }
+
+    @Test
+    @ConfiguredWithCode(value = "/invalid-roles.yml")
+    public void shouldFailWhenRoleNotValid() {
+        // Given
+        final CreateSecretResult foo = createStringSecret("supersecret");
+
+        // When
+        final List<StringCredentials> credentials = jenkins.getCredentials().lookup(StringCredentials.class);
+
+        // Then
+        assertThat(credentials)
+                .isEmpty();
+    }
+
+    private CreateSecretResult createStringSecret(String secretString) {
+        final List<Tag> tags = Lists.of(AwsTags.type(Type.string));
+
+        return createSecret(secretString, tags);
+    }
+
+    private CreateSecretResult createSecret(String secretString, List<Tag> tags) {
+        final CreateSecretRequest request = new CreateSecretRequest()
+                .withName(CredentialNames.random())
+                .withSecretString(secretString)
+                .withTags(tags);
+
+        return secretsManager.getClient().createSecret(request);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/AbstractCheckEndpointConfigurationIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/AbstractCheckEndpointConfigurationIT.java
@@ -5,12 +5,12 @@ import org.junit.Test;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
-public abstract class AbstractCheckConnectionIT {
+public abstract class AbstractCheckEndpointConfigurationIT {
 
     protected abstract FormValidationResult validate(String serviceEndpoint, String signingRegion);
 
     @Test
-    public void shouldTestConnection() {
+    public void shouldAllowGoodEndpointConfiguration() {
         // When
         final FormValidationResult result = validate("http://localhost:4584", "us-east-1");
 
@@ -22,7 +22,7 @@ public abstract class AbstractCheckConnectionIT {
     }
 
     @Test
-    public void shouldRevealClientErrorsInTestConnection() {
+    public void shouldRejectBadEndpointConfiguration() {
         // When
         final FormValidationResult result = validate("http://localhost:1", "us-east-1");
 

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/AbstractPluginConfigurationIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/AbstractPluginConfigurationIT.java
@@ -13,6 +13,11 @@ public abstract class AbstractPluginConfigurationIT {
 
     protected abstract void setTagFilters(String key, String value);
 
+    /*
+     * Only 1 role is supported for now (because locating the Add button in HtmlUnit is difficult)
+     */
+    protected abstract void setRoles(String role);
+
     @Test
     public void shouldHaveDefaultConfiguration() {
         final PluginConfiguration config = getPluginConfiguration();
@@ -20,6 +25,7 @@ public abstract class AbstractPluginConfigurationIT {
         assertSoftly(s -> {
             s.assertThat(config.getEndpointConfiguration()).as("Endpoint Configuration").isNull();
             s.assertThat(config.getFilters()).as("Filters").isNull();
+            s.assertThat(config.getBeta()).as("Beta Features").isNull();
         });
     }
 
@@ -50,5 +56,20 @@ public abstract class AbstractPluginConfigurationIT {
         assertThat(config.getFilters().getTag())
                 .extracting("key", "value")
                 .containsOnly("product", "foobar");
+    }
+
+    @Test
+    public void shouldCustomiseRoles() {
+        // Given
+        final String foo = "arn:aws:iam::111111111111:role/foo-role";
+        setRoles(foo);
+
+        // When
+        final PluginConfiguration config = getPluginConfiguration();
+
+        // Then
+        assertThat(config.getBeta().getRoles().getArns())
+                .extracting("value")
+                .containsOnly(foo);
     }
 }

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/CheckEndpointConfigurationApiIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/CheckEndpointConfigurationApiIT.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.credentials.secretsmanager.config;
 
 import io.jenkins.plugins.credentials.secretsmanager.util.FormValidationResult;
 import io.jenkins.plugins.credentials.secretsmanager.util.Rules;
+import io.jenkins.plugins.credentials.secretsmanager.util.FormValidationResult;
 import org.junit.Rule;
 import org.junit.rules.RuleChain;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -12,7 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class CheckConnectionApiIT extends AbstractCheckConnectionIT {
+public class CheckEndpointConfigurationApiIT extends AbstractCheckEndpointConfigurationIT {
 
     public final JenkinsRule jenkins = new JenkinsRule();
 
@@ -24,7 +25,7 @@ public class CheckConnectionApiIT extends AbstractCheckConnectionIT {
     @Override
     protected FormValidationResult validate(String serviceEndpoint, String signingRegion) {
         final JenkinsRule.JSONWebResponse response = doPost(
-                    String.format("descriptorByName/io.jenkins.plugins.credentials.secretsmanager.config.EndpointConfiguration/testConnection?serviceEndpoint=%s&signingRegion=%s", serviceEndpoint, signingRegion),
+                    String.format("descriptorByName/io.jenkins.plugins.credentials.secretsmanager.config.EndpointConfiguration/testEndpointConfiguration?serviceEndpoint=%s&signingRegion=%s", serviceEndpoint, signingRegion),
                     "");
 
         final ParsedBody parsedBody = getValidationMessage(response.getContentAsString(StandardCharsets.UTF_8));

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/CheckEndpointConfigurationWebIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/CheckEndpointConfigurationWebIT.java
@@ -1,9 +1,5 @@
 package io.jenkins.plugins.credentials.secretsmanager.config;
 
-import com.gargoylesoftware.htmlunit.ElementNotFoundException;
-import com.gargoylesoftware.htmlunit.html.DomNode;
-import com.gargoylesoftware.htmlunit.html.HtmlButton;
-import com.gargoylesoftware.htmlunit.html.HtmlElement;
 import io.jenkins.plugins.credentials.secretsmanager.util.FormValidationResult;
 import io.jenkins.plugins.credentials.secretsmanager.util.JenkinsConfiguredWithWebRule;
 import io.jenkins.plugins.credentials.secretsmanager.util.PluginConfigurationForm;
@@ -11,11 +7,9 @@ import io.jenkins.plugins.credentials.secretsmanager.util.Rules;
 import org.junit.Rule;
 import org.junit.rules.RuleChain;
 
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
-public class CheckConnectionWebIT extends AbstractCheckConnectionIT {
+public class CheckEndpointConfigurationWebIT extends AbstractCheckEndpointConfigurationIT {
 
     public final JenkinsConfiguredWithWebRule jenkins = new JenkinsConfiguredWithWebRule();
 
@@ -26,15 +20,14 @@ public class CheckConnectionWebIT extends AbstractCheckConnectionIT {
 
     @Override
     protected FormValidationResult validate(String serviceEndpoint, String signingRegion) {
-
-        AtomicReference<FormValidationResult> result = new AtomicReference<>();
+        final AtomicReference<FormValidationResult> result = new AtomicReference<>();
 
         jenkins.configure(f -> {
             final PluginConfigurationForm form = new PluginConfigurationForm(f);
 
             form.setEndpointConfiguration(serviceEndpoint, signingRegion);
 
-            final FormValidationResult r = form.clickValidateButton("Test Connection");
+            final FormValidationResult r = form.clickValidateButton("Test Endpoint Configuration");
             result.set(r);
         });
 

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/PluginCasCConfigurationIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/PluginCasCConfigurationIT.java
@@ -26,6 +26,11 @@ public class PluginCasCConfigurationIT extends AbstractPluginConfigurationIT {
     }
 
     @Override
+    protected void setRoles(String role) {
+        // no-op (configured by annotations)
+    }
+
+    @Override
     @Test
     @ConfiguredWithCode("/default.yml")
     public void shouldHaveDefaultConfiguration() {
@@ -44,5 +49,12 @@ public class PluginCasCConfigurationIT extends AbstractPluginConfigurationIT {
     @ConfiguredWithCode("/custom-tag.yml")
     public void shouldCustomiseTagFilter() {
         super.shouldCustomiseTagFilter();
+    }
+
+    @Override
+    @Test
+    @ConfiguredWithCode("/custom-roles.yml")
+    public void shouldCustomiseRoles() {
+        super.shouldCustomiseRoles();
     }
 }

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/PluginWebConfigurationIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/PluginWebConfigurationIT.java
@@ -35,6 +35,15 @@ public class PluginWebConfigurationIT extends AbstractPluginConfigurationIT {
         });
     }
 
+    @Override
+    protected void setRoles(String role) {
+        r.configure(f -> {
+            final PluginConfigurationForm form = new PluginConfigurationForm(f);
+
+            form.setRole(role);
+        });
+    }
+
     @Test
     public void shouldCustomiseAndResetConfiguration() {
         r.configure(f -> {
@@ -42,6 +51,7 @@ public class PluginWebConfigurationIT extends AbstractPluginConfigurationIT {
 
             form.setEndpointConfiguration("http://localhost:4584", "us-east-1");
             form.setFilter("product", "foobar");
+            form.setRole("arn:aws:iam::123456789012:role/marketingadminrole");
         });
 
         final PluginConfiguration configBefore = getPluginConfiguration();
@@ -49,6 +59,7 @@ public class PluginWebConfigurationIT extends AbstractPluginConfigurationIT {
         assertSoftly(s -> {
             s.assertThat(configBefore.getEndpointConfiguration()).as("Endpoint Configuration").isNotNull();
             s.assertThat(configBefore.getFilters().getTag()).as("Filters").isNotNull();
+            s.assertThat(configBefore.getBeta().getRoles()).as("Roles").isNotNull();
         });
 
         r.configure(f -> {
@@ -62,6 +73,7 @@ public class PluginWebConfigurationIT extends AbstractPluginConfigurationIT {
         assertSoftly(s -> {
             s.assertThat(configAfter.getEndpointConfiguration()).as("Endpoint Configuration").isNull();
             s.assertThat(configAfter.getFilters()).as("Filters").isNull();
+            s.assertThat(configAfter.getBeta().getRoles()).as("Roles").isNull();
         });
     }
 }

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/supplier/ListSecretsOperationTest.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/supplier/ListSecretsOperationTest.java
@@ -1,4 +1,4 @@
-package io.jenkins.plugins.credentials.secretsmanager;
+package io.jenkins.plugins.credentials.secretsmanager.supplier;
 
 import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.ResponseMetadata;

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/supplier/ListsTest.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/supplier/ListsTest.java
@@ -1,0 +1,67 @@
+package io.jenkins.plugins.credentials.secretsmanager.supplier;
+
+import com.amazonaws.services.secretsmanager.model.Tag;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class ListsTest {
+
+    // Concat //
+
+    @Test
+    public void shouldConcat() {
+        assertThat(Lists.concat("foo", Arrays.asList("bar", "baz")))
+                .containsExactly("foo", "bar", "baz");
+    }
+
+    @Test
+    public void shouldConcatToEmptyList() {
+        assertThat(Lists.concat("foo", Collections.emptyList()))
+                .containsExactly("foo");
+    }
+
+    // toMap //
+
+    @Test
+    public void shouldTransformNullListToMap() {
+        assertThat(Lists.toMap(null, Tag::getKey, Tag::getValue))
+                .isEmpty();
+    }
+
+    @Test
+    public void shouldTransformEmptyListToMap() {
+        final List<Tag> tags = Collections.emptyList();
+
+        assertThat(Lists.toMap(tags, Tag::getKey, Tag::getValue))
+                .isEmpty();
+    }
+
+    @Test
+    public void shouldTransformListToMap() {
+        final List<Tag> tags = com.google.common.collect.Lists.newArrayList(
+                newTag("foo", "1"),
+                newTag("bar", "2"));
+
+        assertThat(Lists.toMap(tags, Tag::getKey, Tag::getValue))
+                .containsOnly(entry("foo", "1"), entry("bar", "2"));
+    }
+
+    @Test
+    public void shouldNotTransformListWithDuplicateKeysToMap() {
+        final List<Tag> tags = com.google.common.collect.Lists.newArrayList(
+                newTag("foo", "3"),
+                newTag("foo", "2"));
+
+        assertThatIllegalStateException()
+                .isThrownBy(() -> Lists.toMap(tags, Tag::getKey, Tag::getValue));
+    }
+
+    private static Tag newTag(String key, String value) {
+        return new Tag().withKey(key).withValue(value);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/supplier/OptionalsTest.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/supplier/OptionalsTest.java
@@ -1,0 +1,21 @@
+package io.jenkins.plugins.credentials.secretsmanager.supplier;
+
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionalsTest {
+    @Test
+    public void shouldStreamOptional() {
+        assertThat(Optionals.stream(Optional.of("foo")))
+                .containsExactly("foo");
+    }
+
+    @Test
+    public void shouldStreamEmptyOptional() {
+        assertThat(Optionals.stream(Optional.empty()))
+                .isEmpty();
+    }
+}

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/supplier/ParallelSupplierTest.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/supplier/ParallelSupplierTest.java
@@ -1,0 +1,42 @@
+package io.jenkins.plugins.credentials.secretsmanager.supplier;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ParallelSupplierTest {
+
+    private static final Supplier<Integer> ONE = () -> 1;
+    private static final Supplier<Integer> TWO = () -> 2;
+    private static final Supplier<Integer> THREE = () -> 3;
+
+    private static <T> Supplier<Collection<T>> newParallelSupplier(Supplier<T>... suppliers) {
+        final Collection<Supplier<T>> supplierCollection = Arrays.asList(suppliers);
+        return new ParallelSupplier<>(supplierCollection);
+    }
+
+    @Test
+    public void shouldSupplyNothing() {
+        final Supplier<Collection<Integer>> supplier = newParallelSupplier();
+
+        assertThat(supplier.get()).isEmpty();
+    }
+
+    @Test
+    public void shouldSupplyOneThing() {
+        final Supplier<Collection<Integer>> supplier = newParallelSupplier(ONE);
+
+        assertThat(supplier.get()).containsExactly(1);
+    }
+
+    @Test
+    public void shouldSupplyMultipleThings() {
+        final Supplier<Collection<Integer>> supplier = newParallelSupplier(ONE, TWO, THREE);
+
+        assertThat(supplier.get()).containsExactly(1, 2, 3);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/util/PluginConfigurationForm.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/util/PluginConfigurationForm.java
@@ -19,6 +19,7 @@ public class PluginConfigurationForm {
     public void clear() {
         this.clearEndpointConfiguration();
         this.clearFilters();
+        this.clearRoles();
     }
 
     public void clearFilters() {
@@ -30,7 +31,24 @@ public class PluginConfigurationForm {
 
         form.getInputByName("_.tag").setChecked(true);
         form.getInputByName("_.key").setValueAttribute(key);
-        form.getInputByName("_.value").setValueAttribute(value);
+        // The Jenkins config form HTML is not hierarchical, necessitating this fragile selector.
+        form.getInputsByName("_.value").stream()
+                .reduce((first, second) -> second)
+                .ifPresent(lastValueInputInForm -> lastValueInputInForm.setValueAttribute(value));
+    }
+
+    public void clearRoles() {
+        form.getInputByName("_.roles").setChecked(false);
+    }
+
+    public void setRole(String arn) {
+        form.getInputByName("_.beta").setChecked(true);
+        form.getInputByName("_.roles").setChecked(true);
+        // TODO Use the 'Add' button to test multiple roles
+        final HtmlInput input = form
+                .getElementsByAttribute("div", "name", "arns").get(0)
+                .getOneHtmlElementByAttribute("input", "name", "_.value");
+        input.setValueAttribute(arn);
     }
 
     public void clearEndpointConfiguration() {

--- a/src/test/resources/custom-roles.yml
+++ b/src/test/resources/custom-roles.yml
@@ -1,0 +1,5 @@
+unclassified:
+  awsCredentialsProvider:
+    beta:
+      roles:
+        - arn:aws:iam::111111111111:role/foo-role

--- a/src/test/resources/invalid-roles.yml
+++ b/src/test/resources/invalid-roles.yml
@@ -1,0 +1,10 @@
+# Integration test for cross-account roles
+
+unclassified:
+  awsCredentialsProvider:
+    beta:
+      roles:
+        - arn:rol/malformatted
+    endpointConfiguration:
+      serviceEndpoint: http://localhost:4584
+      signingRegion: us-east-1


### PR DESCRIPTION
Implements [JENKINS-59670](https://issues.jenkins-ci.org/browse/JENKINS-59670)

Support secrets retrieval from multiple AWS accounts, using cross-account IAM roles.

## To Do

- [x] Role configuration (CasC)
- [x] Role configuration (Web UI)
- [x] Cross-account `CredentialsProvider`
- [ ] Cross-account `SecretSource`
- [x] Credential namespacing policy (or what to do if 2 secrets from different accounts have the same name)
- [ ] Feature integration test **[Blocked by Moto]**
- [x] Docs
- [ ] Allow admins to stop the plugin calling Secrets Manager in the primary account (for environments where the primary account is only a thin proxy to other accounts with cross-account roles)