### PR TITLE
Support a "prefix" configuration to decouple credential name from AWS Secret ID

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -319,6 +319,7 @@ You can set plugin configuration using Jenkins [Configuration As Code](https://g
 ```yaml
 unclassified:
   awsCredentialsProvider:
+    prefix: foo/bar # optional
     filters:
       tag:
         key: product

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/PluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/PluginConfiguration.java
@@ -19,6 +19,7 @@ public class PluginConfiguration extends GlobalConfiguration {
      */
     private EndpointConfiguration endpointConfiguration;
 
+    private String prefix;
     private Filters filters;
 
     public PluginConfiguration() {
@@ -40,6 +41,17 @@ public class PluginConfiguration extends GlobalConfiguration {
         save();
     }
 
+    public String getPrefix() {
+        return prefix;
+    }
+
+    @DataBoundSetter
+    @SuppressWarnings("unused")
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+        save();
+    }
+
     public Filters getFilters() {
         return filters;
     }
@@ -57,6 +69,7 @@ public class PluginConfiguration extends GlobalConfiguration {
         // Workaround: Set any optional struct fields to null before binding configuration.
         // https://groups.google.com/forum/#!msg/jenkinsci-dev/MuRJ-yPRRoo/AvoPZAgbAAAJ
         this.endpointConfiguration = null;
+        this.prefix = null;
         this.filters = null;
 
         req.bindJSON(this, json);


### PR DESCRIPTION
This plugin has worked great for us so far, but we'd like to have a way to decouple the credential name from the AWS Secret ID.  While using the secret ID as the credential (or `SecretSource`) name, you quickly run into issues where you have to either:
1. Run a single Jenkins instance in an AWS account,
2. Share credentials across Jenkins instances in an AWS account, or
3. Add a "prefix" to your credentials in configuration-as-code or pipelines that use credentials:
```
  securityRealm:
    github:
      clientID: "${jenkins/<jenkins-name>/github-oauth-client-id}"
      clientSecret: "${jenkins/<jenkins-name>/github-oauth-client-secret}"
```

While `3` is possible, it makes your configuration and pipelines more brittle and less portable.  Ideally, we would be able to spin up any number of Jenkins instances in our account and have them all able to keep their credentials separate, while sharing config between them.  This is most obvious when putting GitHub OAuth secrets in AWS Secrets Manager - these secrets cannot be shared between Jenkins instances since they're tied to a specific callback URL.

This PR adds another config option (and environment variable) that allows "namespacing" credentials with a prefix in AWS Secrets Manager.  This means each Jenkins instance can have its own namespace, but when credentials (or `SecretSource`s) are resolved by Jenkins, they're no longer namespaced.

For instance, if your `prefix` is `jenkins/new-jenkins/`, and you have the following interpolation in your configuration-as-code: `${github-oauth-client-secret}`, then the plugin will look for a secret in Secret Manager with ID `jenkins/new-jenkins/github-oauth-client-secret`.  Similarly, when credentials are loaded, they're filtered by the `prefix` (in addition to any tag filters), and then the `prefix` is removed from the beginning of the credential name.

Another tangential benefit is when using a `prefix`, you can scope your `secretsmanager:GetSecretValue` permission down to `arn:aws:secretsmanager:${region}:${accountId}:secret:prefix*`, which is much easier than using a tag condition in IAM.

TODO:
- [ ] Tests
- [ ] Documentation