### PR TITLE
Documentation: Add authentication instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Access credentials from AWS Secrets Manager in your Jenkins jobs.
 
 ## Contents
 
+- [Authentication](authentication/index.md)
 - [Caching](caching/index.md)
 - [Filters](filters/index.md)
 - [Networking](networking/index.md)

--- a/docs/authentication/index.md
+++ b/docs/authentication/index.md
@@ -1,0 +1,19 @@
+# Authentication
+
+Configure the plugin to authenticate with AWS.
+
+The plugin *authenticates* with a single primary AWS account. You then *authorize* it with IAM to access Secrets Manager in one or more accounts.
+
+Authentication methods:
+
+- EC2 Instance Profiles.
+- EC2 Container Service credentials.
+- Environment variables (set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` before starting Jenkins).
+- Java properties (set `aws.accessKeyId` and `aws.secretKey` before starting Jenkins).
+- User profile (configure `~/.aws/credentials` before starting Jenkins).
+- Web Identity Token credentials.
+
+Recommendations:
+
+- Use EC2 Instance Profiles when running Jenkins on EC2.
+- Only use the long-lived access key methods (environment variables, Java properties, user profile) when there is no other choice. For example, when Jenkins is outside of AWS.


### PR DESCRIPTION
Add explicit instructions for authentication.

Partly addresses [JENKINS-61938](https://issues.jenkins-ci.org/browse/JENKINS-61938) by stating how the plugin currently supports authentication when running outside of AWS.