### PR TITLE
Add filter by name support

### DIFF
--- a/docs/filters/index.md
+++ b/docs/filters/index.md
@@ -8,7 +8,7 @@ Notes:
 
 - These are client-side filters. As such they only provide usability benefits. They have no security benefits, as Jenkins still fetches the full secret list from AWS.
 - The SecretSource implementation does not use the filters, as they are not relevant to it.
-- Filters are `AND`'d when multiple filters are specified.
+- Filters are AND'd when multiple filters are specified.
 
 ## Tag Filter
 
@@ -27,7 +27,8 @@ unclassified:
 
 ## Name Filter
 
-You can choose to only show credentials where name contains a specifed string. This can be useful if you use namespacing in your AWS Secret name.
+You can choose to only show credentials where AWS Secret name contains a specifed string. This can be useful if you use namespacing in your AWS Secret name.
+Note: `name` relates to the name given to the AWS Secret which aligns with the Jenkins Credential ID.
 
 Example:
 AWS Secret is namespaced for Jenkins integration environment.

--- a/docs/filters/index.md
+++ b/docs/filters/index.md
@@ -8,6 +8,7 @@ Notes:
 
 - These are client-side filters. As such they only provide usability benefits. They have no security benefits, as Jenkins still fetches the full secret list from AWS.
 - The SecretSource implementation does not use the filters, as they are not relevant to it.
+- Filters are `AND`'d when multiple filters are specified.
 
 ## Tag Filter
 
@@ -22,4 +23,21 @@ unclassified:
       tag:
         key: product
         value: foo
+```
+
+## Name Filter
+
+You can choose to only show credentials where name contains a specifed string. This can be useful if you use namespacing in your AWS Secret name.
+
+Example:
+AWS Secret is namespaced for Jenkins integration environment.
+AWS Secret name = `itg/jenkins/github_access_token`
+`pattern` = `itg/jenkins`.
+
+```yaml
+unclassified:
+  awsCredentialsProvider:
+    filters:
+      name:
+        pattern: itg/jenkins
 ```

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/AwsCredentialsProvider.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/AwsCredentialsProvider.java
@@ -53,8 +53,7 @@ public class AwsCredentialsProvider extends CredentialsProvider {
     private final AwsCredentialsStore store = new AwsCredentialsStore(this);
 
     private final Supplier<Collection<IdCredentials>> credentialsSupplier =
-            //memoizeWithExpiration(AwsCredentialsProvider::fetchCredentials, Duration.ofMinutes(5));
-            memoizeWithExpiration(AwsCredentialsProvider::fetchCredentials, Duration.ofSeconds(30));
+            memoizeWithExpiration(AwsCredentialsProvider::fetchCredentials, Duration.ofMinutes(5));
 
     @Override
     @NonNull

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/AwsCredentialsProvider.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/AwsCredentialsProvider.java
@@ -109,9 +109,20 @@ public class AwsCredentialsProvider extends CredentialsProvider {
         final AWSSecretsManager client = builder.build();
 
         final Predicate<SecretListEntry> secretFilter;
-        if (filters != null && filters.getTag() != null) {
-            final Tag filterTag = new Tag().withKey(filters.getTag().getKey()).withValue(filters.getTag().getValue());
-            secretFilter = s -> Optional.ofNullable(s.getTags()).orElse(Collections.emptyList()).contains(filterTag);
+        if (filters != null && (filters.getTag() != null || filters.getName() != null)) {
+
+            if (filters.getTag() != null) {
+                final Tag filterTag = new Tag().withKey(filters.getTag().getKey()).withValue(filters.getTag().getValue());
+
+                if (filters.getName() != null) {
+                    secretFilter = s -> Optional.ofNullable(s.getTags()).orElse(Collections.emptyList()).contains(filterTag) &&
+                                        s.getName().contains(filters.getName().getPattern());
+                } else {
+                    secretFilter = s -> Optional.ofNullable(s.getTags()).orElse(Collections.emptyList()).contains(filterTag);
+                }
+            } else {
+                secretFilter = s -> s.getName().contains(filters.getName().getPattern());
+            }
         } else {
             secretFilter = s -> true;
         }

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/AwsCredentialsProvider.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/AwsCredentialsProvider.java
@@ -115,11 +115,9 @@ public class AwsCredentialsProvider extends CredentialsProvider {
             if (filters.getTag() != null) {
                 final Tag filterTag = new Tag().withKey(filters.getTag().getKey()).withValue(filters.getTag().getValue());
                 secretFilters.add(s -> Optional.ofNullable(s.getTags()).orElse(Collections.emptyList()).contains(filterTag));
-                LOG.log(Level.CONFIG, "add filter: " + filters.getTag());
             }
             if (filters.getName() != null) {
                 secretFilters.add(s -> s.getName().contains(filters.getName().getPattern()));
-                LOG.log(Level.CONFIG, "add filter: " + filters.getName());
             }
         }
 

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Filters.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Filters.java
@@ -20,20 +20,32 @@ public class Filters extends AbstractDescribableImpl<Filters> implements Seriali
      * with one of the specified values.)
      */
     private Tag tag;
+    private Name name;
 
     @DataBoundConstructor
-    public Filters(Tag tag) {
+    public Filters(Tag tag, Name name) {
         this.tag = tag;
+        this.name = name;
     }
 
     public Tag getTag() {
         return tag;
     }
 
+    public Name getName() {
+        return name;
+    }
+
     @DataBoundSetter
     @SuppressWarnings("unused")
     public void setTag(Tag tag) {
         this.tag = tag;
+    }
+
+    @DataBoundSetter
+    @SuppressWarnings("unused")
+    public void setName(Name name) {
+        this.name = name;
     }
 
     @Extension

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Name.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Name.java
@@ -33,10 +33,6 @@ public class Name extends AbstractDescribableImpl<Name> implements Serializable 
         this.pattern = pattern;
     }
 
-    public String toString() {
-        return "Filter Name: \'" + pattern + "\'";
-    }
-
     @Extension
     @Symbol("filters")
     @SuppressWarnings("unused")

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Name.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Name.java
@@ -1,0 +1,46 @@
+package io.jenkins.plugins.credentials.secretsmanager.config;
+
+import io.jenkins.plugins.credentials.secretsmanager.Messages;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import java.io.Serializable;
+
+import javax.annotation.Nonnull;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+
+public class Name extends AbstractDescribableImpl<Name> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String pattern;
+
+    @DataBoundConstructor
+    public Name(String pattern) {
+        this.pattern = pattern;
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    @DataBoundSetter
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
+    @Extension
+    @Symbol("filters")
+    @SuppressWarnings("unused")
+    public static class DescriptorImpl extends Descriptor<Name> {
+        @Override
+        @Nonnull
+        public String getDisplayName() {
+            return Messages.name();
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Name.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Name.java
@@ -33,6 +33,10 @@ public class Name extends AbstractDescribableImpl<Name> implements Serializable 
         this.pattern = pattern;
     }
 
+    public String toString() {
+        return "Filter Name: \'" + pattern + "\'";
+    }
+
     @Extension
     @Symbol("filters")
     @SuppressWarnings("unused")

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Tag.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Tag.java
@@ -44,6 +44,10 @@ public class Tag extends AbstractDescribableImpl<Tag> implements Serializable {
         this.value = value;
     }
 
+    public String toString() {
+        return "Filter Tag: \'" + key + ":" + value + "\'";
+    }
+
     @Extension
     @Symbol("filters")
     @SuppressWarnings("unused")

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Tag.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Tag.java
@@ -44,10 +44,6 @@ public class Tag extends AbstractDescribableImpl<Tag> implements Serializable {
         this.value = value;
     }
 
-    public String toString() {
-        return "Filter Tag: \'" + key + ":" + value + "\'";
-    }
-
     @Extension
     @Symbol("filters")
     @SuppressWarnings("unused")

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/Messages.properties
@@ -7,6 +7,7 @@ certificate = Certificate
 file = Secret File
 filters = Filters
 tag = Tag
+name = Name
 endpointConfiguration = Endpoint Configuration
 success = Success
 failure = Failure

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Filters/config_en.properties
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Filters/config_en.properties
@@ -1,1 +1,3 @@
+
 tag=Tag
+name=Name

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Name/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Name/config.jelly
@@ -1,5 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-    <f:optionalProperty field="tag" title="${%tag}" />
-    <f:optionalProperty field="name" title="${%name}" />
+    <f:entry field="pattern" title="${%pattern}">
+        <f:textbox />
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Name/config_en.properties
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Name/config_en.properties
@@ -1,0 +1,1 @@
+pattern = Pattern

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/FiltersIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/FiltersIT.java
@@ -57,19 +57,11 @@ public class FiltersIT {
     @ConfiguredWithCode(value = "/names.yml")
     public void shouldFilterByName() {
         // Given
-        final CreateSecretOperation.Result foo = createSecret("dev/supersecret", opts -> {
-            opts.tags = Maps.of(
-                    Tags.type, Type.string,
-                    "environment", "dev");
-        });
-        final CreateSecretOperation.Result bar = createOtherSecret("itg/supersecret", opts -> {
-            opts.tags = Maps.of(
-                    Tags.type, Type.string,
-                    "environment", "itg");
-        });
+        final CreateSecretResult foo = createSecret("dev/supersecret", Lists.of(AwsTags.type(Type.string), AwsTags.tag("environment", "dev")));
+        final CreateSecretResult bar = createSecret("itg/supersecret", Lists.of(AwsTags.type(Type.string), AwsTags.tag("environment", "itg")));
 
         // When
-        final List<StringCredentials> credentials = lookupCredentials(StringCredentials.class);
+        final List<StringCredentials> credentials = jenkins.getCredentials().lookup(StringCredentials.class);
 
         // Then
         assertThat(credentials)

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/FiltersIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/FiltersIT.java
@@ -52,4 +52,28 @@ public class FiltersIT {
 
         return secretsManager.getClient().createSecret(request);
     }
+    
+    @Test
+    @ConfiguredWithCode(value = "/names.yml")
+    public void shouldFilterByName() {
+        // Given
+        final CreateSecretOperation.Result foo = createSecret("dev/supersecret", opts -> {
+            opts.tags = Maps.of(
+                    Tags.type, Type.string,
+                    "environment", "dev");
+        });
+        final CreateSecretOperation.Result bar = createOtherSecret("itg/supersecret", opts -> {
+            opts.tags = Maps.of(
+                    Tags.type, Type.string,
+                    "environment", "itg");
+        });
+
+        // When
+        final List<StringCredentials> credentials = lookupCredentials(StringCredentials.class);
+
+        // Then
+        assertThat(credentials)
+                .extracting("id", "secret")
+                .containsOnly(tuple(foo.getName(), Secret.fromString("dev/supersecret")));
+    }
 }

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/AbstractPluginConfigurationIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/AbstractPluginConfigurationIT.java
@@ -51,20 +51,20 @@ public abstract class AbstractPluginConfigurationIT {
         // Then
         assertThat(config.getFilters().getTag())
                 .extracting("key", "value")
-                .containsOnly("product", "foobars");
+                .containsOnly("product", "foobar");
     }
 
     @Test
     public void shouldCustomiseNameFilter() {
         // Given
-        setNameFilters("dev");
+        setNameFilters("dev/jenkins");
 
         // When
         final PluginConfiguration config = getPluginConfiguration();
 
         // Then
-        assertThat(config.getFilters().getName())
-                .extracting("id", "pattern")
-                .containsOnly("del");
+        assertThat(config.getFilters().getName().getPattern())
+                .as("check Name filter pattern")
+                .isEqualTo("dev/jenkins");
     }
 }

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/AbstractPluginConfigurationIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/AbstractPluginConfigurationIT.java
@@ -51,7 +51,7 @@ public abstract class AbstractPluginConfigurationIT {
         // Then
         assertThat(config.getFilters().getTag())
                 .extracting("key", "value")
-                .containsOnly("product", "foobar");
+                .containsOnly("product", "foobars");
     }
 
     @Test
@@ -64,7 +64,7 @@ public abstract class AbstractPluginConfigurationIT {
 
         // Then
         assertThat(config.getFilters().getName())
-                .extracting("pattern")
-                .containsOnly("dev");
+                .extracting("id", "pattern")
+                .containsOnly("del");
     }
 }

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/AbstractPluginConfigurationIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/AbstractPluginConfigurationIT.java
@@ -13,6 +13,8 @@ public abstract class AbstractPluginConfigurationIT {
 
     protected abstract void setTagFilters(String key, String value);
 
+    protected abstract void setNameFilters(String pattern);
+
     @Test
     public void shouldHaveDefaultConfiguration() {
         final PluginConfiguration config = getPluginConfiguration();
@@ -50,5 +52,19 @@ public abstract class AbstractPluginConfigurationIT {
         assertThat(config.getFilters().getTag())
                 .extracting("key", "value")
                 .containsOnly("product", "foobar");
+    }
+
+    @Test
+    public void shouldCustomiseNameFilter() {
+        // Given
+        setNameFilters("dev");
+
+        // When
+        final PluginConfiguration config = getPluginConfiguration();
+
+        // Then
+        assertThat(config.getFilters().getName())
+                .extracting("pattern")
+                .containsOnly("dev");
     }
 }

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/PluginCasCConfigurationIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/PluginCasCConfigurationIT.java
@@ -26,6 +26,11 @@ public class PluginCasCConfigurationIT extends AbstractPluginConfigurationIT {
     }
 
     @Override
+    protected void setNameFilters(String pattern) {
+        // no-op (configured by annotations)
+    }
+
+    @Override
     @Test
     @ConfiguredWithCode("/default.yml")
     public void shouldHaveDefaultConfiguration() {
@@ -44,5 +49,12 @@ public class PluginCasCConfigurationIT extends AbstractPluginConfigurationIT {
     @ConfiguredWithCode("/custom-tag.yml")
     public void shouldCustomiseTagFilter() {
         super.shouldCustomiseTagFilter();
+    }
+
+    @Override
+    @Test
+    @ConfiguredWithCode("/custom-name.yml")
+    public void shouldCustomiseNameFilter() {
+        super.shouldCustomiseNameFilter();
     }
 }

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/PluginWebConfigurationIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/PluginWebConfigurationIT.java
@@ -30,17 +30,15 @@ public class PluginWebConfigurationIT extends AbstractPluginConfigurationIT {
     protected void setTagFilters(String key, String value) {
         r.configure(f -> {
             final PluginConfigurationForm form = new PluginConfigurationForm(f);
-            form.setFilter(key, value);
+            form.setFilterByTag(key, value);
         });
     }
 
+    @Override
     protected void setNameFilters(String pattern) {
-        r.configure(form -> {
-            form.getInputByName("_.filters").setChecked(true);
-
-            form.getInputByName("_.tag").setChecked(false);
-            form.getInputByName("_.name").setChecked(true);
-            form.getInputByName("_.pattern").setValueAttribute(pattern);
+        r.configure(f -> {
+            final PluginConfigurationForm form = new PluginConfigurationForm(f);
+            form.setFilterByName(pattern);
         });
     }
 
@@ -50,7 +48,7 @@ public class PluginWebConfigurationIT extends AbstractPluginConfigurationIT {
             final PluginConfigurationForm form = new PluginConfigurationForm(f);
 
             form.setEndpointConfiguration("http://localhost:4584", "us-east-1");
-            form.setFilter("product", "foobar");
+            form.setFilterByTag("product", "foobar");
         });
 
         final PluginConfiguration configBefore = getPluginConfiguration();

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/PluginWebConfigurationIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/PluginWebConfigurationIT.java
@@ -30,8 +30,17 @@ public class PluginWebConfigurationIT extends AbstractPluginConfigurationIT {
     protected void setTagFilters(String key, String value) {
         r.configure(f -> {
             final PluginConfigurationForm form = new PluginConfigurationForm(f);
-
             form.setFilter(key, value);
+        });
+    }
+
+    protected void setNameFilters(String pattern) {
+        r.configure(form -> {
+            form.getInputByName("_.filters").setChecked(true);
+
+            form.getInputByName("_.tag").setChecked(false);
+            form.getInputByName("_.name").setChecked(true);
+            form.getInputByName("_.pattern").setValueAttribute(pattern);
         });
     }
 

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/util/PluginConfigurationForm.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/util/PluginConfigurationForm.java
@@ -25,12 +25,21 @@ public class PluginConfigurationForm {
         form.getInputByName("_.filters").setChecked(false);
     }
 
-    public void setFilter(String key, String value) {
+    public void setFilterByTag(String key, String value) {
         form.getInputByName("_.filters").setChecked(true);
 
         form.getInputByName("_.tag").setChecked(true);
+        form.getInputByName("_.name").setChecked(false);
         form.getInputByName("_.key").setValueAttribute(key);
         form.getInputByName("_.value").setValueAttribute(value);
+    }
+
+    public void setFilterByName(String pattern) {
+        form.getInputByName("_.filters").setChecked(true);
+
+        form.getInputByName("_.tag").setChecked(false);
+        form.getInputByName("_.name").setChecked(true);
+        form.getInputByName("_.pattern").setValueAttribute(pattern);
     }
 
     public void clearEndpointConfiguration() {

--- a/src/test/resources/custom-name.yml
+++ b/src/test/resources/custom-name.yml
@@ -2,4 +2,4 @@ unclassified:
   awsCredentialsProvider:
     filters:
       name:
-        pattern: dev
+        pattern: dev/jenkins

--- a/src/test/resources/custom-name.yml
+++ b/src/test/resources/custom-name.yml
@@ -1,0 +1,5 @@
+unclassified:
+  awsCredentialsProvider:
+    filters:
+      name:
+        pattern: dev

--- a/src/test/resources/name-and-tag.yml
+++ b/src/test/resources/name-and-tag.yml
@@ -1,0 +1,13 @@
+# Integration test for filter by name
+
+unclassified:
+  awsCredentialsProvider:
+    filters:
+      tag:
+        key: product
+        value: roadrunner
+      name:
+        pattern: dev/jenkins
+    endpointConfiguration:
+      serviceEndpoint: http://localhost:4584
+      signingRegion: us-east-1

--- a/src/test/resources/name.yml
+++ b/src/test/resources/name.yml
@@ -4,7 +4,7 @@ unclassified:
   awsCredentialsProvider:
     filters:
       name:
-        pattern: dev
+        pattern: dev/jenkins
     endpointConfiguration:
       serviceEndpoint: http://localhost:4584
       signingRegion: us-east-1

--- a/src/test/resources/names.yml
+++ b/src/test/resources/names.yml
@@ -1,4 +1,4 @@
-# Integration test for filter by tag
+# Integration test for filter by name
 
 unclassified:
   awsCredentialsProvider:

--- a/src/test/resources/names.yml
+++ b/src/test/resources/names.yml
@@ -1,0 +1,10 @@
+# Integration test for filter by tag
+
+unclassified:
+  awsCredentialsProvider:
+    filters:
+      name:
+        pattern: dev
+    endpointConfiguration:
+      serviceEndpoint: http://localhost:4584
+      signingRegion: us-east-1


### PR DESCRIPTION
Support filtering of AWS Secrets Manager Secrets within plugin using the (friendly) name applied to the secret at creation time.

Large organisations that stores secrets in AWS Secrets Manager, may/can store secrets for many services in addition to CI systems. Providing name-spacing of secrets by name aids maintenance.

