### PR TITLE
Remove unneeded buildPlugin configuration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,8 +4,4 @@ def configurations = [
     [ platform: "linux", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
     [ platform: "linux", jdk: "11", jenkins: recentLTS, javaLevel: "8" ],
 ]
-buildPlugin(
-  findbugs: [run: true, archive: true],
-  checkstyle: [run: true, archive: true],
-  configurations: configurations
-)
+buildPlugin(configurations: configurations)


### PR DESCRIPTION
Checkstyle and spotbugs are being enabled by default in https://github.com/jenkins-infra/pipeline-library/pull/121, (assuming that checkstyle is bound to a phase in the build directly, the task is no longer directly invoked)