### PR TITLE
Fix Javadoc and code style issues

### DIFF
--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/BetaConfigurator.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/BetaConfigurator.java
@@ -1,6 +1,6 @@
 package io.jenkins.plugins.credentials.secretsmanager.config;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
@@ -50,7 +50,7 @@ public class BetaConfigurator extends BaseConfigurator<Beta>
     @Override
     @NonNull
     public Set<Attribute<Beta,?>> describe() {
-        return Sets.newHashSet(
+        return ImmutableSet.of(
                 new MultivaluedAttribute<Beta, Client>("clients", Client.class)
                         .setter((target, clients) -> {
                             final Clients container = new Clients(new HashSet<>(clients));

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/ClientConfigurator.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/ClientConfigurator.java
@@ -1,6 +1,6 @@
 package io.jenkins.plugins.credentials.secretsmanager.config;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import io.jenkins.plugins.casc.Attribute;
@@ -41,7 +41,7 @@ public class ClientConfigurator  extends BaseConfigurator<Client>
     @Override
     @NonNull
     public Set<Attribute<Client,?>> describe() {
-        return Sets.newHashSet(
+        return ImmutableSet.of(
                 new Attribute<Client, CredentialsProvider>("credentialsProvider", CredentialsProvider.class),
                 new Attribute<Client, EndpointConfiguration>("endpointConfiguration", EndpointConfiguration.class),
                 new Attribute<Client, String>("region", String.class)

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/CredentialsFactory.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/CredentialsFactory.java
@@ -33,6 +33,8 @@ public abstract class CredentialsFactory {
      * @param name the secret's name (must be unique within the AWS account)
      * @param description the secret's description
      * @param tags the secret's AWS tags
+     * @param client the Secrets Manager client that will retrieve the secret's value on demand
+     * @return a credential (if one could be constructed from the secret's properties)
      */
     public static Optional<StandardCredentials> create(String name, String description, Map<String, String> tags, AWSSecretsManager client) {
         final String type = tags.getOrDefault(Tags.type, "");

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/supplier/ParallelSupplierTest.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/supplier/ParallelSupplierTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,28 +15,23 @@ public class ParallelSupplierTest {
     private static final Supplier<Integer> TWO = () -> 2;
     private static final Supplier<Integer> THREE = () -> 3;
 
-    private static <T> Supplier<Collection<T>> newParallelSupplier(Supplier<T>... suppliers) {
-        final Collection<Supplier<T>> supplierCollection = Arrays.asList(suppliers);
-        return new ParallelSupplier<>(supplierCollection);
-    }
-
     @Test
     public void shouldSupplyNothing() {
-        final Supplier<Collection<Integer>> supplier = newParallelSupplier();
+        final Supplier<Collection<Integer>> supplier = new ParallelSupplier<>(Collections.emptyList());
 
         assertThat(supplier.get()).isEmpty();
     }
 
     @Test
     public void shouldSupplyOneThing() {
-        final Supplier<Collection<Integer>> supplier = newParallelSupplier(ONE);
+        final Supplier<Collection<Integer>> supplier = new ParallelSupplier<>(Collections.singletonList(ONE));
 
         assertThat(supplier.get()).containsExactly(1);
     }
 
     @Test
     public void shouldSupplyMultipleThings() {
-        final Supplier<Collection<Integer>> supplier = newParallelSupplier(ONE, TWO, THREE);
+        final Supplier<Collection<Integer>> supplier = new ParallelSupplier<>(Arrays.asList(ONE, TWO, THREE));
 
         assertThat(supplier.get()).containsExactly(1, 2, 3);
     }


### PR DESCRIPTION
Fix outstanding javadoc and code style warnings, except for `AwsSshUserPrivateKey` (which we cannot do anything about, because it is obligated to implement a deprecated method).