### PR TITLE
Fix: Revert broken Symbol annotation in Tag class

### DIFF
--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Tag.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Tag.java
@@ -46,7 +46,7 @@ public class Tag extends AbstractDescribableImpl<Tag> implements Serializable {
     }
 
     @Extension
-    @Symbol("tag")
+    @Symbol("filters")
     @SuppressWarnings("unused")
     public static class DescriptorImpl extends Descriptor<Tag> {
         @Override


### PR DESCRIPTION
Fixes [JENKINS-63685](https://issues.jenkins-ci.org/browse/JENKINS-63685)