### PR TITLE
Use bom-2.222.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-def recentLTS = "2.204.6"
+def recentLTS = "2.222.4"
 def configurations = [
     [ platform: "linux", jdk: "8", jenkins: null ],
     [ platform: "linux", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <revision>0.5.1</revision>
         <changelist>-SNAPSHOT</changelist>
         <java.level>8</java.level>
-        <jenkins.version>2.204.6</jenkins.version>
+        <jenkins.version>2.222.4</jenkins.version>
         <moto.version>1.3.15.29</moto.version>
     </properties>
 
@@ -57,8 +57,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.204.x</artifactId>
-                <version>12</version>
+                <artifactId>bom-2.222.x</artifactId>
+                <version>13</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -89,15 +89,19 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>bouncycastle-api</artifactId>
-            <version>2.18</version>
+            <groupId>org.jenkinsci.plugins</groupId>
+            <artifactId>pipeline-model-definition</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jenkinsci.plugins</groupId>
-            <artifactId>pipeline-model-definition</artifactId>
-            <version>1.7.2</version>
+            <groupId>io.jenkins.configuration-as-code</groupId>
+            <artifactId>test-harness</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>bouncycastle-api</artifactId>
+            <version>2.18</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -108,30 +112,9 @@
         </dependency>
         <!-- Workarounds -->
         <dependency>
-            <groupId>io.jenkins.configuration-as-code</groupId>
-            <artifactId>test-harness</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.dataformat</groupId>
-                    <artifactId>jackson-dataformat-yaml</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
             <version>2.11.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.jenkins.plugins</groupId>
-            <artifactId>snakeyaml-api</artifactId>
-            <version>1.26.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Use bom-2.222.x to obtain the full pipeline-model-definition dependency stack from the BOM.