### PR TITLE
Help needed: Configure AWS/Plugin

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,4 @@
+HELP!
 # AWS Secrets Manager Credentials Provider
 
 [![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/aws-secrets-manager-credentials-provider-plugin/master)](https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Faws-secrets-manager-credentials-provider-plugin/activity/)


### PR DESCRIPTION
(NOT a real PR)

Hi, I'm struggling trying to install and configure this plugin.

I've a simple EC2 instance with a IAM role attached, I've installed the plugin and configured the login as follow via casc:
```
jenkins:
  systemMessage: "Jenkins configured automatically by Jenkins Configuration as Code plugin\n\n"
  securityRealm:
    local:
      allowsSignup: false
      users:
        - id: "admin"
          password: "${admin-password-test}"
  authorizationStrategy: loggedInUsersCanDoAnything
  ```
  
  On AWS Secrets Manager I've a secret called admin-password-test.
  
  The login works so the `SecretSource` works. 
  
  My problem is that I was expecting to find all the other secrets that I have on Secrets Manager as credentials in Jenkins. 
 
 Have I misconfigured something or misunderstood the way the plugin works?
 
 Can someone help me, please?
 
 Thanks.
 
 