### PR TITLE
feat: Log AWSSecretsManagerException if thrown

### DIFF
--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/AwsSecretSource.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/AwsSecretSource.java
@@ -44,6 +44,7 @@ public class AwsSecretSource extends SecretSource {
             LOG.info(e.getMessage());
             return Optional.empty();
         } catch (AWSSecretsManagerException e) {
+            LOG.error(e.getMessage());
             // Unrecoverable errors
             throw new IOException(e);
         }


### PR DESCRIPTION
Log an error message that may prove useful if an AWSSecretsManagerException is thrown