### PR TITLE
Clarify config and tagging sections in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -356,7 +356,7 @@ Go to `Manage Jenkins` > `Configure System` > `AWS Secrets Manager Credentials P
 
 Available settings:
 
-- Cache of credential names (on/off)
+- [Cache](caching/index.md) (on/off)
 - Endpoint Configuration
   - Service Endpoint
   - Signing Region

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,11 +24,7 @@ Access credentials from AWS Secrets Manager in your Jenkins jobs.
 - `CredentialsProvider` and `SecretSource` API support.
 - Credential metadata caching (duration: 5 minutes).
  
-## Setup 
-
-### Jenkins
-
-Install and configure the plugin.
+## Setup
 
 ### IAM
 
@@ -63,6 +59,12 @@ Example:
     ]
 }
 ```
+
+### Jenkins
+
+The plugin uses the AWS Java SDK to communicate with Secrets Manager. If you are running Jenkins outside EC2 or EKS you may need to manually configure the SDK to authenticate with AWS. See the [authentication](authentication/index.md) guide for more information.
+
+Then, install and [configure](#Configuration) the plugin.
 
 ## Usage
 
@@ -344,12 +346,7 @@ node {
 
 ## Configuration
 
-Two sources of configuration drive how the plugin works:
-
-- *AWS Java SDK configuration* (outside of Jenkins). Consult the AWS SDK documentation to find where to put the SDK configuration.
-- *Plugin configuration* (inside Jenkins). You can use the Jenkins Web UI or CasC to customise it.
-
-The AWS SDK configuration does most of the work; the plugin configuration adds extras on the top. In most installations you do not need to change the plugin configuration.
+The plugin has a couple of optional settings to fine-tune its behavior. In most installations you do not need to change these settings. If you need to change the configuration, you can use the Web UI or CasC.
 
 ### Web UI
 
@@ -359,7 +356,7 @@ Go to `Manage Jenkins` > `Configure System` > `AWS Secrets Manager Credentials P
 
 Available settings:
 
-- Cache (on/off)
+- Cache of credential names (on/off)
 - Endpoint Configuration
   - Service Endpoint
   - Signing Region

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,12 +36,33 @@ Give Jenkins read access to Secrets Manager with an IAM policy.
 
 Required permissions:
 
-- `secretsmanager:GetSecretValue` (Resource: `*`)
+- `secretsmanager:GetSecretValue`
 - `secretsmanager:ListSecrets`
 
 Optional permissions:
 
 - `kms:Decrypt` (if you use a customer-managed KMS key to encrypt the secret)
+
+Example:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowJenkinsToGetSecretValues",
+            "Effect": "Allow",
+            "Action": "secretsmanager:GetSecretValue",
+            "Resource": "*"
+        },
+        {
+            "Sid": "AllowJenkinsToListSecrets",
+            "Effect": "Allow",
+            "Action": "secretsmanager:ListSecrets"
+        }
+    ]
+}
+```
 
 ## Usage
 
@@ -56,9 +77,7 @@ Note: Any string secret is accessible through SecretSource, but only a secret wi
 
 The plugin allows secrets from Secrets Manager to be used as Jenkins credentials.
  
-Jenkins must know which [credential type](https://jenkins.io/doc/pipeline/steps/credentials-binding/) a secret is meant to be (e.g. Secret Text, Username With Password), in order to present it as a credential. To do this, **you MUST annotate the secrets with the relevant tags** as shown in the sections below. If the credentials cache is enabled you must also wait for that to refresh before the newly annotated secrets appear in Jenkins.
-
-To restate the above, you MUST add these tags or the corresponding credentials will not appear in Jenkins.
+Jenkins must know which [credential type](https://jenkins.io/doc/pipeline/steps/credentials-binding/) a secret is meant to be (e.g. Secret Text, Username With Password), in order to present it as a credential. To do this, **you MUST add the relevant AWS tags to the secrets in Secrets Manager**, as shown in the sections below. (If the credentials cache is enabled you must also wait for that to refresh before the newly annotated secrets appear in Jenkins.) Without these tags, the corresponding credentials will not appear in Jenkins.
 
 #### Secret Text
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,7 @@ Give Jenkins read access to Secrets Manager with an IAM policy.
 
 Required permissions:
 
-- `secretsmanager:GetSecretValue` (resource: `*`)
+- `secretsmanager:GetSecretValue` (Resource: `*`)
 - `secretsmanager:ListSecrets`
 
 Optional permissions:
@@ -56,7 +56,9 @@ Note: Any string secret is accessible through SecretSource, but only a secret wi
 
 The plugin allows secrets from Secrets Manager to be used as Jenkins credentials.
  
-A secret will act as one of the following Jenkins [credential types](https://jenkins.io/doc/pipeline/steps/credentials-binding/), based on the `jenkins:credentials:type` tag that you add to it.
+Jenkins must know which [credential type](https://jenkins.io/doc/pipeline/steps/credentials-binding/) a secret is meant to be (e.g. Secret Text, Username With Password), in order to present it as a credential. To do this, **you MUST annotate the secrets with the relevant tags** as shown in the sections below. If the credentials cache is enabled you must also wait for that to refresh before the newly annotated secrets appear in Jenkins.
+
+To restate the above, you MUST add these tags or the corresponding credentials will not appear in Jenkins.
 
 #### Secret Text
 
@@ -323,7 +325,12 @@ node {
 
 ## Configuration
 
-The plugin's default behavior requires **no configuration**. If you need to change the configuration, you can use the Web UI or CasC.
+Two sources of configuration drive how the plugin works:
+
+- *AWS Java SDK configuration* (outside of Jenkins). Consult the AWS SDK documentation to find where to put the SDK configuration.
+- *Plugin configuration* (inside Jenkins). You can use the Jenkins Web UI or CasC to customise it.
+
+The AWS SDK configuration does most of the work; the plugin configuration adds extras on the top. In most installations you do not need to change the plugin configuration.
 
 ### Web UI
 
@@ -333,6 +340,7 @@ Go to `Manage Jenkins` > `Configure System` > `AWS Secrets Manager Credentials P
 
 Available settings:
 
+- Cache (on/off)
 - Endpoint Configuration
   - Service Endpoint
   - Signing Region
@@ -346,6 +354,7 @@ You can set plugin configuration using Jenkins [Configuration As Code](https://g
 ```yaml
 unclassified:
   awsCredentialsProvider:
+    cache: true  # cache is on by default
     endpointConfiguration:
       serviceEndpoint: http://localhost:4584
       signingRegion: us-east-1


### PR DESCRIPTION
Clarify sections of README:

- Configuration (AWS SDK config vs plugin config)
- Type tags
- New troubleshooting page