### PR TITLE
Added Github App Credentials support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Access credentials from AWS Secrets Manager in your Jenkins jobs.
 - [Filters](filters/index.md)
 - [Networking](networking/index.md)
 - [Screenshots](screenshots/index.md)
+- [Troubleshooting](troubleshooting/index.md)
 - Project
   - [Changelog](https://github.com/jenkinsci/aws-secrets-manager-credentials-provider-plugin/releases)
   - [CI Build](https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Faws-secrets-manager-credentials-provider-plugin/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -272,6 +272,54 @@ node {
 }
 ```
 
+#### Github App Credentials
+
+A github *private key*, with a *github app id*.
+
+- Value: *content*
+- Tags:
+  - `jenkins:credentials:type` = `githubApp`
+  - `jenkins:credentials:appid` = *Github App Id*
+
+The private key format used is PKCS#8 (starts with `-----BEGIN PRIVATE KEY-----`).
+
+##### Example
+
+AWS CLI:
+
+```bash
+openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in pkcs1.key -out pkcs8.key
+aws secretsmanager create-secret --name 'githubapp' --secret-string 'file://pkcs8.key' --tags 'Key=jenkins:credentials:type,Value=githubApp' 'Key=jenkins:credentials:appid,Value=11111' --description 'Github App Credentials'
+```
+
+Declarative Pipeline:
+
+```groovy
+pipeline {
+    agent any
+    environment {
+        GITHUB_APP = credentials('githubapp')
+    }
+    stages {
+        stage('Example') {
+            steps {
+              echo 'Hello world'
+            }
+        }
+    }
+}
+```
+
+Scripted Pipeline:
+
+```groovy
+node {
+    withCredentials([usernamePassword(credentialsId: 'githubapp', usernameVariable: 'GITHUBAPP_USR', passwordVariable: 'GITHUBAPP_PSW')]) {
+        echo 'Hello world'
+    }
+}
+```
+
 ### SecretSource
 
 The plugin allows JCasC to interpolate string secrets from Secrets Manager.

--- a/docs/README.md
+++ b/docs/README.md
@@ -272,7 +272,9 @@ node {
 }
 ```
 
-#### Github App Credentials
+#### Github App Credentials (Optional)
+
+Requires *git-source-branch* plugin to create this credential type
 
 A github *private key*, with a *github app id*.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -173,7 +173,7 @@ node {
 
 #### SSH User Private Key
 
-An SSH *private key*, with a *username*.
+An SSH *Private Key*, with a *Username*.
 
 - Value: *private key*
 - Tags:

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -1,0 +1,7 @@
+# Troubleshooting
+
+If Secrets Manager secrets are not appearing in Jenkins, start here.
+
+## Consult the Jenkins logs
+
+The plugin uses the AWS Java SDK for its interactions with Secrets Manager. When problems occur, the plugin propagates exceptions from the SDK into the Jenkins logs. These exceptions are often a useful starting point to find out what's wrong.

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,16 @@
                     </images>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <argLine>
+                        -javaagent:"${settings.localRepository}"/org/jmockit/jmockit/1.41/jmockit-1.41.jar
+                    </argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.930</version>
+            <version>1.11.955</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <version>1.41</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-branch-source</artifactId>
             <version>2.9.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
             <groupId>org.jmockit</groupId>
             <artifactId>jmockit</artifactId>
             <version>1.41</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-branch-source</artifactId>
             <version>2.9.3</version>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,11 @@
             <version>3.19.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>github-branch-source</artifactId>
+            <version>2.9.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/CredentialsFactory.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/CredentialsFactory.java
@@ -4,6 +4,7 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
+import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsUnavailableException;
 import com.cloudbees.plugins.credentials.SecretBytes;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
@@ -15,6 +16,7 @@ import io.jenkins.plugins.credentials.secretsmanager.factory.file.AwsFileCredent
 import io.jenkins.plugins.credentials.secretsmanager.factory.ssh_user_private_key.AwsSshUserPrivateKey;
 import io.jenkins.plugins.credentials.secretsmanager.factory.string.AwsStringCredentials;
 import io.jenkins.plugins.credentials.secretsmanager.factory.username_password.AwsUsernamePasswordCredentials;
+import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
 
 import java.util.Map;
 import java.util.Optional;
@@ -40,6 +42,7 @@ public abstract class CredentialsFactory {
         final String type = tags.getOrDefault(Tags.type, "");
         final String username = tags.getOrDefault(Tags.username, "");
         final String filename = tags.getOrDefault(Tags.filename, name);
+        final String appId = tags.getOrDefault(Tags.appid, "");
 
         switch (type) {
             case Type.string:
@@ -52,6 +55,8 @@ public abstract class CredentialsFactory {
                 return Optional.of(new AwsCertificateCredentials(name, description, new SecretBytesSupplier(client, name)));
             case Type.file:
                 return Optional.of(new AwsFileCredentials(name, description, filename, new SecretBytesSupplier(client, name)));
+            case Type.githubApp:
+                return Optional.of(new GitHubAppCredentials(CredentialsScope.GLOBAL, name, description, appId, Secret.fromString(new StringSupplier(client, name).get())));
             default:
                 return Optional.empty();
         }

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/Tags.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/Tags.java
@@ -9,6 +9,7 @@ public abstract class Tags {
     public static final String filename = namespace + "filename";
     public static final String type = namespace + "type";
     public static final String username = namespace + "username";
+    public static final String appid = namespace + "appid";
 
     private Tags() {
 

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/Type.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/Type.java
@@ -9,6 +9,7 @@ public abstract class Type {
     public static final String usernamePassword = "usernamePassword";
     public static final String sshUserPrivateKey = "sshUserPrivateKey";
     public static final String string = "string";
+    public static final String githubApp = "githubApp";
 
     private Type() {
 

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/git_app/GitCredentialFactory.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/git_app/GitCredentialFactory.java
@@ -1,0 +1,28 @@
+package io.jenkins.plugins.credentials.secretsmanager.factory.git_app;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import hudson.Extension;
+import hudson.util.Secret;
+import io.jenkins.plugins.credentials.secretsmanager.factory.Type;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
+
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Extension(optional = true)
+public class GitCredentialFactory {
+    private static final Logger LOG = Logger.getLogger(GitCredentialFactory.class.getName());
+
+    public Optional<StandardCredentials> createCredential(String name, String description, String appId, Secret secret) {
+        if (Jenkins.get().getPlugin("github-branch-source") == null) {
+            LOG.warning("Plugin not installed: github-branch-source. Cannot create type: " + Type.githubApp);
+            return Optional.empty();
+        }
+
+        return Optional.of(new GitHubAppCredentials(CredentialsScope.GLOBAL, name, description, appId, secret));
+    }
+}
+

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/GithubAppCredentialsIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/GithubAppCredentialsIT.java
@@ -1,0 +1,196 @@
+package io.jenkins.plugins.credentials.secretsmanager;
+
+import com.amazonaws.services.secretsmanager.model.*;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import hudson.util.ListBoxModel;
+import hudson.util.Secret;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.credentials.secretsmanager.factory.Type;
+import io.jenkins.plugins.credentials.secretsmanager.util.*;
+import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.jenkins.plugins.credentials.secretsmanager.util.assertions.CustomAssertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+public class GithubAppCredentialsIT implements CredentialsTests {
+
+    private static final String APP_ID = "11111";
+    private static final String PRIVATE_KEY = Crypto.newPrivateKey()
+            .replace("-----BEGIN RSA PRIVATE KEY-----", "")
+            .replace("-----END RSA PRIVATE KEY-----", "");;
+
+    public final MyJenkinsConfiguredWithCodeRule jenkins = new MyJenkinsConfiguredWithCodeRule();
+    public final AWSSecretsManagerRule secretsManager = new AutoErasingAWSSecretsManagerRule();
+
+    @Rule
+    public final RuleChain chain = RuleChain
+            .outerRule(Rules.awsAccessKey("fake", "fake"))
+            .around(jenkins)
+            .around(secretsManager);
+
+    @BeforeClass
+    public static void GitHubAppCredentialsExists() {
+        Optional<Class> clazz = getGithubAppCredentialClass();
+        assumeTrue(clazz.isPresent());
+    }
+
+    @Test
+    @ConfiguredWithCode(value = "/integration.yml")
+    public void shouldSupportListView() {
+        // Given
+        final CreateSecretResult foo = createGitHubAppCredentialSecret(APP_ID, PRIVATE_KEY);
+
+        // When
+        final ListBoxModel list = jenkins.getCredentials().list(StandardCredentials.class);
+
+        // Then
+        assertThat(list)
+                .containsOption(APP_ID + "/******", foo.getName());
+    }
+
+    @Test
+    @ConfiguredWithCode(value = "/integration.yml")
+    public void shouldHaveDescriptorIcon() {
+        final CreateSecretResult foo = createGitHubAppCredentialSecret(APP_ID, PRIVATE_KEY);
+        final GitHubAppCredentials ours = lookup(GitHubAppCredentials.class, foo.getName());
+
+        final GitHubAppCredentials theirs = new GitHubAppCredentials(CredentialsScope.GLOBAL, "name", "description", "11111", Secret.fromString("secret"));
+
+        assertThat(ours)
+                .hasSameDescriptorIconAs(theirs);
+    }
+
+    //Cannot test binding because GitHubAppCredential requires connection to api.github.com
+    public void shouldSupportWithCredentialsBinding() {
+        // Given
+        final CreateSecretResult foo = createGitHubAppCredentialSecret(APP_ID, PRIVATE_KEY);
+
+        ListSecretsRequest getSecretValueRequest = new ListSecretsRequest();
+        ListSecretsResult list = secretsManager.getClient().listSecrets(getSecretValueRequest);
+        // When
+        final WorkflowRun run = runPipeline("",
+                "withCredentials([usernamePassword(credentialsId: '" + foo.getName() + "', usernameVariable: 'USR', passwordVariable: 'PSW')]) {",
+                "  echo \"Credential: {username: $USR, password: $PSW}\"",
+                "}");
+
+        // Then
+        assertThat(run)
+                .hasResult(hudson.model.Result.FAILURE)
+                .hasLogContaining("java.io.FileNotFoundException: https://api.github.com/app");
+    }
+
+    //Cannot test binding because GitHubAppCredential requires connection to api.github.com
+    public void shouldSupportEnvironmentBinding() {
+        // Given
+        final CreateSecretResult foo = createGitHubAppCredentialSecret(APP_ID, PRIVATE_KEY);
+
+        // When
+        final WorkflowRun run = runPipeline("",
+                "pipeline {",
+                "  agent none",
+                "  stages {",
+                "    stage('Example') {",
+                "      environment {",
+                "        FOO = credentials('" + foo.getName() + "')",
+                "      }",
+                "      steps {",
+                "        echo \"{variable: $FOO, username: $FOO_USR, password: $FOO_PSW}\"",
+                "      }",
+                "    }",
+                "  }",
+                "}");
+
+        // Then
+        assertThat(run)
+                .hasResult(hudson.model.Result.FAILURE)
+                .hasLogContaining("java.io.FileNotFoundException: https://api.github.com/app");
+    }
+
+    @Test
+    @ConfiguredWithCode(value = "/integration.yml")
+    public void shouldSupportSnapshots() {
+        // Given
+        final CreateSecretResult foo = createGitHubAppCredentialSecret(APP_ID, PRIVATE_KEY);
+        final GitHubAppCredentials before = jenkins.getCredentials().lookup(GitHubAppCredentials.class, foo.getName());
+
+        // When
+        final GitHubAppCredentials after = CredentialSnapshots.snapshot(before);
+
+        // Then
+        //Cannot test password because GitHubAppCredential requires connection to api.github.com
+        assertThat(after)
+                .hasUsername(before.getUsername())
+                .hasId(before.getId());
+    }
+
+    @Test
+    @ConfiguredWithCode(value = "/integration.yml")
+    public void shouldHaveId() {
+        // Given
+        final CreateSecretResult foo = createGitHubAppCredentialSecret(APP_ID, PRIVATE_KEY);
+
+        // When
+        final GitHubAppCredentials credential =
+                jenkins.getCredentials().lookup(GitHubAppCredentials.class, foo.getName());
+
+        // Then
+        assertThat(credential)
+                .hasId(foo.getName());
+    }
+
+    @Test
+    @ConfiguredWithCode(value = "/integration.yml")
+    public void shouldHaveUsername() {
+        // Given
+        final CreateSecretResult foo = createGitHubAppCredentialSecret(APP_ID, PRIVATE_KEY);
+
+        // When
+        final StandardUsernamePasswordCredentials credential =
+                jenkins.getCredentials().lookup(GitHubAppCredentials.class, foo.getName());
+
+        // Then
+        assertThat(credential)
+                .hasUsername(APP_ID);
+    }
+
+    private CreateSecretResult createGitHubAppCredentialSecret(String appId, String privateKey) {
+        final List<Tag> tags = Lists.of(
+                AwsTags.type(Type.githubApp),
+                AwsTags.appid(appId));
+
+        final CreateSecretRequest request = new CreateSecretRequest()
+                .withName(CredentialNames.random())
+                .withSecretString(privateKey)
+                .withTags(tags);
+
+        return secretsManager.getClient().createSecret(request);
+    }
+
+    private WorkflowRun runPipeline(String... pipeline) {
+        return jenkins.getPipelines().run(Strings.m(pipeline));
+    }
+
+    private <C extends StandardCredentials> C lookup(Class<C> type, String id) {
+        return jenkins.getCredentials().lookup(type, id);
+    }
+
+    private static Optional<Class> getGithubAppCredentialClass() {
+        Class githubCredentials;
+        try {
+            githubCredentials = Class.forName("org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials");
+        } catch (Throwable ex) {
+            return Optional.empty();
+        }
+        return Optional.of(githubCredentials);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/GithubAppCredentialsIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/GithubAppCredentialsIT.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.credentials.secretsmanager;
 
 import com.amazonaws.services.secretsmanager.model.*;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
@@ -137,6 +138,7 @@ public class GithubAppCredentialsIT implements CredentialsTests {
     @Test
     @ConfiguredWithCode(value = "/integration.yml")
     public void shouldSupportSnapshots() {
+
         // Given
         final CreateSecretResult foo = createGitHubAppCredentialSecret(APP_ID, PRIVATE_KEY);
         final GitHubAppCredentials before = jenkins.getCredentials().lookup(GitHubAppCredentials.class, foo.getName());
@@ -147,6 +149,7 @@ public class GithubAppCredentialsIT implements CredentialsTests {
         // Then
         assertThat(after)
                 .hasUsername(before.getUsername())
+                .hasPrivateKey(before.getPrivateKey())
                 .hasId(before.getId());
     }
 
@@ -178,6 +181,20 @@ public class GithubAppCredentialsIT implements CredentialsTests {
         // Then
         assertThat(credential)
                 .hasUsername(APP_ID);
+    }
+
+    @Test
+    @ConfiguredWithCode(value = "/integration.yml")
+    public void shouldHavePrivateKey() {
+        // Given
+        final CreateSecretResult foo = createGitHubAppCredentialSecret(APP_ID, PRIVATE_KEY);
+
+        // When
+        final GitHubAppCredentials credential = lookup(GitHubAppCredentials.class, foo.getName());
+
+        // Then
+        assertThat(credential)
+                .hasPrivateKey(PRIVATE_KEY);
     }
 
     private CreateSecretResult createGitHubAppCredentialSecret(String appId, String privateKey) {

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/util/AwsTags.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/util/AwsTags.java
@@ -19,6 +19,10 @@ public abstract class AwsTags {
         return AwsTags.tag(Tags.username, username);
     }
 
+    public static Tag appid(String id) {
+        return AwsTags.tag(Tags.appid, id);
+    }
+
     public static Tag type(String type) {
         return tag(Tags.type, type);
     }

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/util/assertions/CustomAssertions.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/util/assertions/CustomAssertions.java
@@ -5,6 +5,7 @@ import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import hudson.util.ListBoxModel;
+import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
 import org.jenkinsci.plugins.plaincredentials.FileCredentials;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -35,6 +36,10 @@ public class CustomAssertions {
 
     public static SSHUserPrivateKeyAssert assertThat(SSHUserPrivateKey actual) {
         return new SSHUserPrivateKeyAssert(actual);
+    }
+
+    public static GithubAppCredentialsAssert assertThat(GitHubAppCredentials actual) {
+        return new GithubAppCredentialsAssert(actual);
     }
 
     public static WorkflowRunAssert assertThat(WorkflowRun actual) {

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/util/assertions/GithubAppCredentialsAssert.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/util/assertions/GithubAppCredentialsAssert.java
@@ -1,0 +1,62 @@
+package io.jenkins.plugins.credentials.secretsmanager.util.assertions;
+
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import hudson.util.Secret;
+import org.assertj.core.api.AbstractAssert;
+import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
+
+import java.util.Objects;
+
+public class GithubAppCredentialsAssert extends AbstractAssert<GithubAppCredentialsAssert, GitHubAppCredentials> {
+
+    public GithubAppCredentialsAssert(GitHubAppCredentials actual) {
+        super(actual, GithubAppCredentialsAssert.class);
+    }
+
+    public GithubAppCredentialsAssert hasUsername(String username) {
+        isNotNull();
+
+        if (!Objects.equals(actual.getUsername(), username)) {
+            failWithMessage("Expected username to be <%s> but was <%s>", username, actual.getUsername());
+        }
+
+        return this;
+    }
+
+    public GithubAppCredentialsAssert hasPrivateKey(String privateKey) {
+        return hasPrivateKey(Secret.fromString(privateKey));
+    }
+
+    public GithubAppCredentialsAssert hasPrivateKey(Secret privateKey) {
+        isNotNull();
+
+        if (!Objects.equals(actual.getPrivateKey(), privateKey)) {
+            failWithMessage("Expected private keys to be <%s> but was <%s>", privateKey, actual.getPrivateKey());
+        }
+
+        return this;
+    }
+
+    public GithubAppCredentialsAssert hasAppId(String appId) {
+        isNotNull();
+
+        if (!Objects.equals(actual.getAppID(), appId)) {
+            failWithMessage("Expected App Id to be <%s> but was <%s>", appId, actual.getAppID());
+        }
+
+        return this;
+    }
+
+    public GithubAppCredentialsAssert hasSameDescriptorIconAs(StandardUsernamePasswordCredentials theirs) {
+        new StandardCredentialsAssert(actual).hasSameDescriptorIconAs(theirs);
+
+        return this;
+    }
+
+    public GithubAppCredentialsAssert hasId(String id) {
+        new StandardCredentialsAssert(actual).hasId(id);
+
+        return this;
+    }
+
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
I added support for Github App Credentials from the github-branch-source plugin. The github-branch-source plugin is optional and the credentials will only will be created when the plugin is installed.

- [X ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
