### PR TITLE
Set parent POM to 4.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.24</version>
+        <version>4.19</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
4.19 was the last version before the Maven 3.8.1+ requirement was introduced. This is necessary because IntelliJ IDEA's embedded Maven is only at 3.6.3 at the moment.