### PR TITLE
Fix: Hide AWS credential types in Add Credentials wizard

### DIFF
--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/certificate/AwsCertificateCredentials.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/certificate/AwsCertificateCredentials.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.credentials.secretsmanager.factory.certificate;
 
+import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsUnavailableException;
 import com.cloudbees.plugins.credentials.SecretBytes;
 import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
@@ -7,6 +8,7 @@ import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.util.Secret;
+import io.jenkins.plugins.credentials.secretsmanager.AwsCredentialsProvider;
 import io.jenkins.plugins.credentials.secretsmanager.Messages;
 
 import javax.annotation.Nonnull;
@@ -67,6 +69,11 @@ public class AwsCertificateCredentials extends BaseStandardCredentials implement
         @Override
         public String getIconClassName() {
             return "icon-credentials-certificate";
+        }
+
+        @Override
+        public boolean isApplicable(CredentialsProvider provider) {
+            return provider instanceof AwsCredentialsProvider;
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/file/AwsFileCredentials.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/file/AwsFileCredentials.java
@@ -1,14 +1,15 @@
 package io.jenkins.plugins.credentials.secretsmanager.factory.file;
 
+import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.SecretBytes;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import hudson.Extension;
+import io.jenkins.plugins.credentials.secretsmanager.AwsCredentialsProvider;
 import io.jenkins.plugins.credentials.secretsmanager.Messages;
 import org.jenkinsci.plugins.plaincredentials.FileCredentials;
 
 import javax.annotation.Nonnull;
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.function.Supplier;
 
@@ -51,6 +52,11 @@ public class AwsFileCredentials extends BaseStandardCredentials implements FileC
         @Nonnull
         public String getDisplayName() {
             return Messages.file();
+        }
+
+        @Override
+        public boolean isApplicable(CredentialsProvider provider) {
+            return provider instanceof AwsCredentialsProvider;
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/ssh_user_private_key/AwsSshUserPrivateKey.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/ssh_user_private_key/AwsSshUserPrivateKey.java
@@ -1,10 +1,12 @@
 package io.jenkins.plugins.credentials.secretsmanager.factory.ssh_user_private_key;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.util.Secret;
+import io.jenkins.plugins.credentials.secretsmanager.AwsCredentialsProvider;
 import io.jenkins.plugins.credentials.secretsmanager.Messages;
 
 import javax.annotation.Nonnull;
@@ -60,6 +62,11 @@ public class AwsSshUserPrivateKey extends BaseStandardCredentials implements SSH
         @Override
         public String getIconClassName() {
             return "icon-ssh-credentials-ssh-key";
+        }
+
+        @Override
+        public boolean isApplicable(CredentialsProvider provider) {
+            return provider instanceof AwsCredentialsProvider;
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/string/AwsStringCredentials.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/string/AwsStringCredentials.java
@@ -1,8 +1,10 @@
 package io.jenkins.plugins.credentials.secretsmanager.factory.string;
 
+import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import hudson.Extension;
 import hudson.util.Secret;
+import io.jenkins.plugins.credentials.secretsmanager.AwsCredentialsProvider;
 import io.jenkins.plugins.credentials.secretsmanager.Messages;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
@@ -31,6 +33,11 @@ public class AwsStringCredentials extends BaseStandardCredentials implements Str
         @Nonnull
         public String getDisplayName() {
             return Messages.secretText();
+        }
+
+        @Override
+        public boolean isApplicable(CredentialsProvider provider) {
+            return provider instanceof AwsCredentialsProvider;
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/username_password/AwsUsernamePasswordCredentials.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/username_password/AwsUsernamePasswordCredentials.java
@@ -1,10 +1,12 @@
 package io.jenkins.plugins.credentials.secretsmanager.factory.username_password;
 
+import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.util.Secret;
+import io.jenkins.plugins.credentials.secretsmanager.AwsCredentialsProvider;
 import io.jenkins.plugins.credentials.secretsmanager.Messages;
 
 import javax.annotation.Nonnull;
@@ -45,6 +47,11 @@ public class AwsUsernamePasswordCredentials extends BaseStandardCredentials impl
         @Override
         public String getIconClassName() {
             return "icon-credentials-userpass";
+        }
+
+        @Override
+        public boolean isApplicable(CredentialsProvider provider) {
+            return provider instanceof AwsCredentialsProvider;
         }
     }
 }


### PR DESCRIPTION
Fixes #152 