### PR TITLE
Support defining file credentials as SecretString

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ target
 work
 *.releaseBackup
 release.properties
+
+.classpath
+.factorypath
+.project
+.settings/

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/CredentialsFactory.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/CredentialsFactory.java
@@ -16,6 +16,7 @@ import io.jenkins.plugins.credentials.secretsmanager.factory.ssh_user_private_ke
 import io.jenkins.plugins.credentials.secretsmanager.factory.string.AwsStringCredentials;
 import io.jenkins.plugins.credentials.secretsmanager.factory.username_password.AwsUsernamePasswordCredentials;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -68,7 +69,7 @@ public abstract class CredentialsFactory {
             return getSecretValue().match(new SecretValue.Matcher<SecretBytes>() {
                 @Override
                 public SecretBytes string(String str) {
-                    return null;
+                    return SecretBytes.fromBytes(str.getBytes(StandardCharsets.UTF_8));
                 }
 
                 @Override


### PR DESCRIPTION
Hi, I am proposing this change to resolve [issue 131](https://github.com/jenkinsci/aws-secrets-manager-credentials-provider-plugin/issues/131).

This changes allows someone to set a SecretString (in UTF8) as the secret file content instead of a SecretBinary.

I've provided a test for this, please let me know if you need additional testing.

Seb

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
