### PR TITLE
Adding aws.region to the authentication documentation

### DIFF
--- a/docs/authentication/index.md
+++ b/docs/authentication/index.md
@@ -9,7 +9,7 @@ Authentication methods:
 - EC2 Instance Profiles.
 - EC2 Container Service credentials.
 - Environment variables (set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` before starting Jenkins).
-- Java properties (set `aws.accessKeyId` and `aws.secretKey` before starting Jenkins).
+- Java properties (set `aws.accessKeyId`, `aws.secretKey` and `aws.region` before starting Jenkins).
 - User profile (configure `~/.aws/credentials` before starting Jenkins).
 - Web Identity Token credentials.
 


### PR DESCRIPTION
Secrets are not properly retrieved If  `aws.region` is not added to the JVM arguments. I have only added the `aws.region` argument to the auth doc.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

