### PR TITLE
[fix] Update credential icons

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-def recentLTS = "2.289.3"
+def recentLTS = "2.346.2"
 def configurations = [
     [ platform: "linux", jdk: "8", jenkins: null ],
     [ platform: "linux", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-def recentLTS = "2.346.2"
+def recentLTS = "2.346.3"
 def configurations = [
     [ platform: "linux", jdk: "8", jenkins: null ],
     [ platform: "linux", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <revision>1</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <java.level>8</java.level>
-        <jenkins.version>2.346.2</jenkins.version>
+        <jenkins.version>2.346.3</jenkins.version>
     </properties>
 
     <dependencyManagement>
@@ -52,7 +52,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.346.x</artifactId>
-                <version>1500.ve4d05cd32975</version>
+                <version>1654.vcb_69d035fa_20</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -44,14 +44,14 @@
         <revision>1</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <java.level>8</java.level>
-        <jenkins.version>2.289.3</jenkins.version>
+        <jenkins.version>2.346.2</jenkins.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.289.x</artifactId>
+                <artifactId>bom-2.346.x</artifactId>
                 <version>1500.ve4d05cd32975</version>
                 <scope>import</scope>
                 <type>pom</type>

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/certificate/AwsCertificateCredentials.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/certificate/AwsCertificateCredentials.java
@@ -68,7 +68,7 @@ public class AwsCertificateCredentials extends BaseStandardCredentials implement
 
         @Override
         public String getIconClassName() {
-            return "icon-credentials-certificate";
+            return "icon-application-certificate";
         }
 
         @Override

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/ssh_user_private_key/AwsSshUserPrivateKey.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/ssh_user_private_key/AwsSshUserPrivateKey.java
@@ -61,7 +61,7 @@ public class AwsSshUserPrivateKey extends BaseStandardCredentials implements SSH
 
         @Override
         public String getIconClassName() {
-            return "icon-ssh-credentials-ssh-key";
+            return "symbol-fingerprint";
         }
 
         @Override

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/username_password/AwsUsernamePasswordCredentials.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/factory/username_password/AwsUsernamePasswordCredentials.java
@@ -46,7 +46,7 @@ public class AwsUsernamePasswordCredentials extends BaseStandardCredentials impl
 
         @Override
         public String getIconClassName() {
-            return "icon-credentials-userpass";
+            return "symbol-id-card";
         }
 
         @Override

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/transformer/name/removePrefixes/RemovePrefixes/help-prefixes.html
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/transformer/name/removePrefixes/RemovePrefixes/help-prefixes.html
@@ -1,1 +1,0 @@
-<div>The prefix(es) to remove from the string, if present.</div>

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/util/PluginConfigurationForm.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/util/PluginConfigurationForm.java
@@ -25,11 +25,11 @@ public class PluginConfigurationForm {
 
     private static class XPaths {
         private static String dropdownList(String settingName) {
-            return String.format("//div[contains(@class, 'setting-name') and normalize-space(text()) = '%s']/following-sibling::div[contains(@class, 'setting-main')]/select[contains(@class, 'dropdownList')]", settingName);
+            return String.format("//div[contains(@class, 'jenkins-form-label') and normalize-space(text()) = '%s']/following-sibling::div[contains(@class, 'jenkins-select')]/select", settingName);
         }
 
         private static String repeatableAddButtons(String settingName) {
-            return String.format("//div[contains(@class, 'setting-name') and text()='%s']/following-sibling::div[@class='setting-main']//span[contains(string(@class),'repeatable-add')]//button[contains(text(), 'Add')]", settingName);
+            return String.format("//div[contains(@class, 'jenkins-form-label') and text()='%s']/following-sibling::div[@class='setting-main']//span[contains(string(@class),'repeatable-add')]//button[contains(text(), 'Add')]", settingName);
         }
     }
 }


### PR DESCRIPTION
The change proposed utilizes the corresponding icon from core, which respects themes properly.
Current implementation on dark mode:
![Bildschirmfoto 2022-06-23 um 00 36 29](https://user-images.githubusercontent.com/13383509/175166302-c4e6c83c-7a75-44fe-9f30-02dc9d3d0e20.png)
Proposed change:
![Bildschirmfoto 2022-06-23 um 00 39 23](https://user-images.githubusercontent.com/13383509/175166311-99a232be-b9bb-4a7e-a176-b889ca25ae53.png)

cc @chriskilding   
