### PR TITLE
[dependencies] Remove slf4j-api and commons-compress deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,20 +116,6 @@
             <version>2.12.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <!-- Workaround -->
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <!-- Workaround -->
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>1.21</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Remove version pinning for the slf4j-api and commons-compress dependencies, since it no longer seems to be necessary