### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 def recentLTS = "2.361.1"
 def configurations = [
     [ platform: "linux", jdk: "11", jenkins: null ],
-    [ platform: "linux", jdk: "11", jenkins: recentLTS, javaLevel: "11" ],
+    [ platform: "linux", jdk: "11", jenkins: recentLTS ],
 ]
 buildPlugin(configurations: configurations)
 


### PR DESCRIPTION
The javaLevel option is deprecated and does no longer set the Java version. The option is ignored.
This PR removes the unused option.

I'll expedite the merge, once the infrastructure changes on ci.jenkins.io are live, to prevent a failure on the master branch and new PRs.