### PR TITLE
[feature] Use Jenkins proxy settings for Secrets Manager communication

### DIFF
--- a/docs/client/index.md
+++ b/docs/client/index.md
@@ -77,6 +77,34 @@ unclassified:
           secretKey: "${aws-secret-key}"    # e.g. wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 ```
 
+## Client Configuration
+
+The plugin will use the default AWS client configuration if no overrides are set.
+
+If the Jenkins system-wide HTTP proxy is configured, the plugin will use the Jenkins proxy settings:
+
+```yaml
+jenkins:
+  proxy:
+    name: "localhost"
+    port: 5000
+    userName: "user"
+    secretPassword: "fake"
+```
+
+Alternatively you can set the AWS client configuration for the client. This will take precedence over any Jenkins proxy settings that may be present. (This may be useful if you need to apply different HTTP proxy settings just for Secrets Manager.)
+
+```yaml
+unclassified:
+  awsCredentialsProvider:
+    client:
+      clientConfiguration:
+        proxyHost: "localhost"
+        proxyPort: 5000
+        proxyUsername: "user"
+        proxyPassword: "fake"
+```
+
 ## Endpoint Configuration
 
 You can set the AWS endpoint configuration for the client.

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Client.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Client.java
@@ -20,11 +20,15 @@ import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.annotation.Nonnull;
 import java.io.Serializable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.Objects;
 
 public class Client extends AbstractDescribableImpl<Client> implements Serializable {
 
     private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = Logger.getLogger(Client.class.getName());
 
     private CredentialsProvider credentialsProvider;
 
@@ -80,16 +84,20 @@ public class Client extends AbstractDescribableImpl<Client> implements Serializa
         if (region != null && !region.isEmpty()) {
             builder.setRegion(region);
         }
-        
-        ProxyConfiguration proxyConfiguration = Jenkins.get().proxy;
-        if(proxyConfiguration != null) {
-            ClientConfiguration configuration = new ClientConfiguration();
-            configuration.setProxyHost(proxyConfiguration.name);
-            configuration.setProxyPort(proxyConfiguration.port);
-            configuration.setProxyUsername(proxyConfiguration.getUserName());
-            configuration.setProxyPassword(proxyConfiguration.getSecretPassword().getPlainText());
-            configuration.setNonProxyHosts(proxyConfiguration.getNoProxyHost());
-            builder.setClientConfiguration(configuration);
+        try {
+            ProxyConfiguration proxyConfiguration = Jenkins.get().proxy;
+            if(proxyConfiguration != null) {
+                ClientConfiguration configuration = new ClientConfiguration();
+                configuration.setProxyHost(proxyConfiguration.name);
+                configuration.setProxyPort(proxyConfiguration.port);
+                configuration.setProxyUsername(proxyConfiguration.getUserName());
+                configuration.setProxyPassword(proxyConfiguration.getSecretPassword().getPlainText());
+                configuration.setNonProxyHosts(proxyConfiguration.getNoProxyHost());
+                builder.setClientConfiguration(configuration);
+            }
+        } catch (Exception ex) {
+            LOG.warning("AWS Secrets Manager failed to set the proxy configuration");
+            LOG.warning(ex.getMessage());
         }
 
         return builder.build();

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Client.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Client.java
@@ -21,6 +21,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.Optional;
 
 public class Client extends AbstractDescribableImpl<Client> implements Serializable {
 
@@ -78,15 +79,22 @@ public class Client extends AbstractDescribableImpl<Client> implements Serializa
         this.region = Util.fixEmptyAndTrim(region);
     }
 
-    // FIXME work this in
-    private static ProxyConfiguration getProxyConfiguration() {
-        final var jenkins = Jenkins.getInstanceOrNull();
+    static Optional<ProxyConfiguration> getProxyConfiguration() {
+        final var maybeProxyConfiguration = Jenkins.lookup(ProxyConfiguration.class);
 
-        if (jenkins != null) {
-            return jenkins.getProxy();
-        }
+        return Optional.ofNullable(maybeProxyConfiguration);
+    }
 
-        return null;
+    static com.amazonaws.ClientConfiguration toClientConfiguration(ProxyConfiguration proxyConfiguration) {
+        final var configuration = new com.amazonaws.ClientConfiguration();
+
+        configuration.setProxyHost(proxyConfiguration.getName());
+        configuration.setProxyPort(proxyConfiguration.getPort());
+        configuration.setProxyUsername(proxyConfiguration.getUserName());
+        configuration.setProxyPassword(Secret.toString(proxyConfiguration.getSecretPassword()));
+        configuration.setNonProxyHosts(proxyConfiguration.getNoProxyHost());
+
+        return configuration;
     }
 
     public AWSSecretsManager build() {
@@ -95,18 +103,15 @@ public class Client extends AbstractDescribableImpl<Client> implements Serializa
         if (clientConfiguration != null) {
             builder.setClientConfiguration(clientConfiguration.build());
         } else {
+            // If Jenkins has a system-wide proxy configuration set, use it.
+            // Otherwise, leave the AWS client configuration as default.
             final var proxyConfiguration = getProxyConfiguration();
-            if (proxyConfiguration != null) {
-                final var configuration = new com.amazonaws.ClientConfiguration();
 
-                configuration.setProxyHost(proxyConfiguration.getName());
-                configuration.setProxyPort(proxyConfiguration.getPort());
-                configuration.setProxyUsername(proxyConfiguration.getUserName());
-                configuration.setProxyPassword(Secret.toString(proxyConfiguration.getSecretPassword()));
-                configuration.setNonProxyHosts(proxyConfiguration.getNoProxyHost());
+            proxyConfiguration.ifPresent(p -> {
+                final var proxyClientConfiguration = toClientConfiguration(p);
 
-                builder.setClientConfiguration(configuration);
-            }
+                builder.setClientConfiguration(proxyClientConfiguration);
+            });
         }
 
         if (credentialsProvider != null) {

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Client.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Client.java
@@ -1,12 +1,15 @@
 package io.jenkins.plugins.credentials.secretsmanager.config;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import jenkins.model.Jenkins;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import hudson.ProxyConfiguration;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.credentials.secretsmanager.Messages;
 import io.jenkins.plugins.credentials.secretsmanager.config.credentialsProvider.CredentialsProvider;
@@ -76,6 +79,17 @@ public class Client extends AbstractDescribableImpl<Client> implements Serializa
 
         if (region != null && !region.isEmpty()) {
             builder.setRegion(region);
+        }
+        
+        ProxyConfiguration proxyConfiguration = Jenkins.get().proxy;
+        if(proxyConfiguration != null) {
+            ClientConfiguration configuration = new ClientConfiguration();
+            configuration.setProxyHost(proxyConfiguration.name);
+            configuration.setProxyPort(proxyConfiguration.port);
+            configuration.setProxyUsername(proxyConfiguration.getUserName());
+            configuration.setProxyPassword(proxyConfiguration.getSecretPassword().getPlainText());
+            configuration.setNonProxyHosts(proxyConfiguration.getNoProxyHost());
+            builder.setClientConfiguration(configuration);
         }
 
         return builder.build();

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Client.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/Client.java
@@ -79,10 +79,12 @@ public class Client extends AbstractDescribableImpl<Client> implements Serializa
         this.region = Util.fixEmptyAndTrim(region);
     }
 
-    static Optional<ProxyConfiguration> getProxyConfiguration() {
-        final var maybeProxyConfiguration = Jenkins.lookup(ProxyConfiguration.class);
+    private static Optional<ProxyConfiguration> getProxyConfiguration() {
+        // jenkins object could be null
+        final var maybeJenkins = Optional.ofNullable(Jenkins.getInstanceOrNull());
 
-        return Optional.ofNullable(maybeProxyConfiguration);
+        // proxy object could also be null
+        return maybeJenkins.flatMap(j -> Optional.ofNullable(j.getProxy()));
     }
 
     static com.amazonaws.ClientConfiguration toClientConfiguration(ProxyConfiguration proxyConfiguration) {

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/ClientConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/ClientConfiguration.java
@@ -1,0 +1,117 @@
+package io.jenkins.plugins.credentials.secretsmanager.config;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.util.Secret;
+import io.jenkins.plugins.credentials.secretsmanager.Messages;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.util.Objects;
+
+public class ClientConfiguration extends AbstractDescribableImpl<ClientConfiguration> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String nonProxyHosts;
+    private String proxyHost;
+    private Integer proxyPort;
+    private String proxyUsername;
+    private Secret proxyPassword;
+
+    @DataBoundConstructor
+    public ClientConfiguration(String nonProxyHosts, String proxyHost, Integer proxyPort, String proxyUsername, Secret proxyPassword) {
+        this.nonProxyHosts = nonProxyHosts;
+        this.proxyHost = proxyHost;
+        this.proxyPort = proxyPort;
+        this.proxyUsername = proxyUsername;
+        this.proxyPassword = proxyPassword;
+    }
+
+    public String getNonProxyHosts() {
+        return nonProxyHosts;
+    }
+
+    @DataBoundSetter
+    public void setNonProxyHosts(String nonProxyHosts) {
+        this.nonProxyHosts = nonProxyHosts;
+    }
+
+    public String getProxyHost() {
+        return proxyHost;
+    }
+
+    @DataBoundSetter
+    public void setProxyHost(String proxyHost) {
+        this.proxyHost = proxyHost;
+    }
+
+    public Integer getProxyPort() {
+        return proxyPort;
+    }
+
+    @DataBoundSetter
+    public void setProxyPort(Integer proxyPort) {
+        this.proxyPort = proxyPort;
+    }
+
+    public String getProxyUsername() {
+        return proxyUsername;
+    }
+
+    @DataBoundSetter
+    public void setProxyUsername(String proxyUsername) {
+        this.proxyUsername = proxyUsername;
+    }
+
+    public Secret getProxyPassword() {
+        return proxyPassword;
+    }
+
+    @DataBoundSetter
+    public void setProxyPassword(Secret proxyPassword) {
+        this.proxyPassword = proxyPassword;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClientConfiguration that = (ClientConfiguration) o;
+        return Objects.equals(proxyPort, that.proxyPort) && Objects.equals(nonProxyHosts, that.nonProxyHosts) && Objects.equals(proxyHost, that.proxyHost) && Objects.equals(proxyUsername, that.proxyUsername) && Objects.equals(proxyPassword, that.proxyPassword);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nonProxyHosts, proxyHost, proxyPort, proxyUsername, proxyPassword);
+    }
+
+    public com.amazonaws.ClientConfiguration build() {
+        final var configuration = new com.amazonaws.ClientConfiguration();
+
+        configuration.setNonProxyHosts(nonProxyHosts);
+        configuration.setProxyHost(proxyHost);
+        if (proxyPort != null) {
+            configuration.setProxyPort(proxyPort);
+        }
+        configuration.setProxyUsername(proxyUsername);
+        configuration.setProxyPassword(Secret.toString(proxyPassword));
+
+        return configuration;
+    }
+
+    @Extension
+    @Symbol("clientConfiguration")
+    @SuppressWarnings("unused")
+    public static class DescriptorImpl extends Descriptor<ClientConfiguration> {
+        @Override
+        @Nonnull
+        public String getDisplayName() {
+            return Messages.clientConfiguration();
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/PluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/config/PluginConfiguration.java
@@ -64,7 +64,7 @@ public class PluginConfiguration extends GlobalConfiguration {
 
     protected Object readResolve() {
         if (endpointConfiguration != null) {
-            client = new Client(null, endpointConfiguration, null);
+            client = new Client(null, null, endpointConfiguration, null);
             endpointConfiguration = null;
         }
 

--- a/src/main/java/io/jenkins/plugins/credentials/secretsmanager/supplier/CredentialsSupplier.java
+++ b/src/main/java/io/jenkins/plugins/credentials/secretsmanager/supplier/CredentialsSupplier.java
@@ -90,7 +90,7 @@ public class CredentialsSupplier implements Supplier<Collection<StandardCredenti
 
     private static AWSSecretsManager createClient(PluginConfiguration config) {
         final Client clientConfig = Optional.ofNullable(config.getClient())
-                .orElse(new Client(null, null, null));
+                .orElse(new Client(null, null, null, null));
 
         return clientConfig.build();
     }

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/Messages.properties
@@ -42,3 +42,4 @@ hide = Hide
 removePrefix = Remove Prefix
 removePrefixes = Remove Prefixes
 prefix = Prefix
+clientConfiguration = Client Configuration

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Client/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Client/config.jelly
@@ -1,5 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:optionalProperty field="clientConfiguration" title="${%clientConfiguration}" />
     <f:dropdownDescriptorSelector field="credentialsProvider" default="${descriptor.defaultCredentialsProvider}" title="${%credentialsProvider}" />
     <f:optionalProperty field="endpointConfiguration" title="${%endpointConfiguration}" />
     <f:entry title="${%region}" field="region" description="${%leaveBlankToAutoDetect}">

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Client/config_en.properties
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Client/config_en.properties
@@ -1,3 +1,4 @@
+clientConfiguration = Client Configuration
 credentialsProvider = Credentials Provider
 endpointConfiguration = Endpoint Configuration
 leaveBlankToAutoDetect = Leave blank to auto-detect

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Client/help-clientConfiguration.html
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/Client/help-clientConfiguration.html
@@ -1,0 +1,2 @@
+<p>Override the AWS client configuration.</p>
+<p>When this is in default mode, the plugin will automatically use the Jenkins HTTP proxy settings if you have configured them.</p>

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/ClientConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/ClientConfiguration/config.jelly
@@ -1,0 +1,18 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="${%nonProxyHosts}">
+        <f:textbox field="nonProxyHosts" />
+    </f:entry>
+    <f:entry title="${%proxyHost}">
+        <f:textbox field="proxyHost" />
+    </f:entry>
+    <f:entry title="${%proxyPort}">
+        <f:number field="proxyPort" min="0" max="65535" />
+    </f:entry>
+    <f:entry title="${%proxyUsername}">
+        <f:textbox field="proxyUsername" />
+    </f:entry>
+    <f:entry title="${%proxyPassword}">
+        <f:password field="proxyPassword" />
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/ClientConfiguration/config_en.properties
+++ b/src/main/resources/io/jenkins/plugins/credentials/secretsmanager/config/ClientConfiguration/config_en.properties
@@ -1,0 +1,5 @@
+nonProxyHosts = Non-Proxy Hosts
+proxyHost = Proxy Host
+proxyPort = Proxy Port
+proxyUsername = Proxy Username
+proxyPassword = Proxy Password

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/ClientTest.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/ClientTest.java
@@ -1,0 +1,32 @@
+package io.jenkins.plugins.credentials.secretsmanager.config;
+
+import hudson.ProxyConfiguration;
+import org.junit.Test;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+public class ClientTest {
+
+    @Test
+    public void shouldConvertProxyConfigurationToClientConfiguration() {
+        // Given
+        final var host = "localhost";
+        final var port = 8000;
+        final var noProxyHost = "example.com";
+        final var username = "foo";
+        final var password = "fake";
+        final var proxyConfiguration = new ProxyConfiguration(host, port, username, password, noProxyHost);
+
+        // When
+        final var clientConfiguration = Client.toClientConfiguration(proxyConfiguration);
+
+        // Then
+        assertSoftly(s -> {
+           s.assertThat(clientConfiguration.getProxyHost()).as("Host").isEqualTo(host);
+           s.assertThat(clientConfiguration.getProxyPort()).as("Port").isEqualTo(port);
+           s.assertThat(clientConfiguration.getProxyUsername()).as("Username").isEqualTo(username);
+           s.assertThat(clientConfiguration.getProxyPassword()).as("Password").isEqualTo(password);
+           s.assertThat(clientConfiguration.getNonProxyHosts()).as("Non-Proxy Hosts").isEqualTo(noProxyHost);
+        });
+    }
+}

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/client/clientConfiguration/AbstractClientConfigurationIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/client/clientConfiguration/AbstractClientConfigurationIT.java
@@ -13,16 +13,6 @@ public abstract class AbstractClientConfigurationIT {
     protected abstract void setClientConfiguration(String nonProxyHosts, String proxyHost, int proxyPort, String proxyUsername, String proxyPassword);
 
     @Test
-    public void shouldHaveDefaultClientConfiguration() {
-        // When
-        final var config = getPluginConfiguration();
-
-        // Then
-        assertThat(config.getClient().getClientConfiguration())
-                .isNull();
-    }
-
-    @Test
     public void shouldHaveClientConfiguration() {
         // Given
         final var nonProxyHosts = "example.com";

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/client/clientConfiguration/AbstractClientConfigurationIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/client/clientConfiguration/AbstractClientConfigurationIT.java
@@ -1,0 +1,43 @@
+package io.jenkins.plugins.credentials.secretsmanager.config.client.clientConfiguration;
+
+import hudson.util.Secret;
+import io.jenkins.plugins.credentials.secretsmanager.config.ClientConfiguration;
+import io.jenkins.plugins.credentials.secretsmanager.config.PluginConfiguration;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class AbstractClientConfigurationIT {
+    protected abstract PluginConfiguration getPluginConfiguration();
+
+    protected abstract void setClientConfiguration(String nonProxyHosts, String proxyHost, int proxyPort, String proxyUsername, String proxyPassword);
+
+    @Test
+    public void shouldHaveDefaultClientConfiguration() {
+        // When
+        final var config = getPluginConfiguration();
+
+        // Then
+        assertThat(config.getClient().getClientConfiguration())
+                .isNull();
+    }
+
+    @Test
+    public void shouldHaveClientConfiguration() {
+        // Given
+        final var nonProxyHosts = "example.com";
+        final var proxyHost = "localhost";
+        final var proxyPort = 5000;
+        final var proxyUsername = "user";
+        final var proxyPassword = "fake";
+        setClientConfiguration(nonProxyHosts, proxyHost, proxyPort, proxyUsername, proxyPassword);
+
+        // When
+        final var config = getPluginConfiguration();
+
+        // Then
+        assertThat(config.getClient().getClientConfiguration())
+                .isEqualTo(new ClientConfiguration(nonProxyHosts, proxyHost, proxyPort, proxyUsername, Secret.fromString(proxyPassword)));
+    }
+
+}

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/client/clientConfiguration/CasCClientConfigurationIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/client/clientConfiguration/CasCClientConfigurationIT.java
@@ -21,14 +21,6 @@ public class CasCClientConfigurationIT extends AbstractClientConfigurationIT {
         // no-op (configured by annotations)
     }
 
-
-    @Override
-    @Test
-    @ConfiguredWithCode("/default.yml")
-    public void shouldHaveDefaultClientConfiguration() {
-        super.shouldHaveDefaultClientConfiguration();
-    }
-
     @Override
     @Test
     @ConfiguredWithCode("/config/client/clientConfiguration.yml")

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/client/clientConfiguration/CasCClientConfigurationIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/client/clientConfiguration/CasCClientConfigurationIT.java
@@ -1,0 +1,38 @@
+package io.jenkins.plugins.credentials.secretsmanager.config.client.clientConfiguration;
+
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.credentials.secretsmanager.config.PluginConfiguration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class CasCClientConfigurationIT extends AbstractClientConfigurationIT {
+    @Rule
+    public final JenkinsRule r = new JenkinsConfiguredWithCodeRule();
+
+    @Override
+    protected PluginConfiguration getPluginConfiguration() {
+        return (PluginConfiguration) r.jenkins.getDescriptor(PluginConfiguration.class);
+    }
+
+    @Override
+    protected void setClientConfiguration(String nonProxyHosts, String proxyHost, int proxyPort, String proxyUsername, String proxyPassword) {
+        // no-op (configured by annotations)
+    }
+
+
+    @Override
+    @Test
+    @ConfiguredWithCode("/default.yml")
+    public void shouldHaveDefaultClientConfiguration() {
+        super.shouldHaveDefaultClientConfiguration();
+    }
+
+    @Override
+    @Test
+    @ConfiguredWithCode("/config/client/clientConfiguration.yml")
+    public void shouldHaveClientConfiguration() {
+        super.shouldHaveClientConfiguration();
+    }
+}

--- a/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/client/clientConfiguration/WebClientConfigurationIT.java
+++ b/src/test/java/io/jenkins/plugins/credentials/secretsmanager/config/client/clientConfiguration/WebClientConfigurationIT.java
@@ -1,0 +1,27 @@
+package io.jenkins.plugins.credentials.secretsmanager.config.client.clientConfiguration;
+
+import io.jenkins.plugins.credentials.secretsmanager.config.PluginConfiguration;
+import io.jenkins.plugins.credentials.secretsmanager.util.JenkinsConfiguredWithWebRule;
+import org.junit.Rule;
+
+public class WebClientConfigurationIT extends AbstractClientConfigurationIT {
+    @Rule
+    public final JenkinsConfiguredWithWebRule r = new JenkinsConfiguredWithWebRule();
+
+    @Override
+    protected PluginConfiguration getPluginConfiguration() {
+        return (PluginConfiguration) r.jenkins.getDescriptor(PluginConfiguration.class);
+    }
+
+    @Override
+    protected void setClientConfiguration(String nonProxyHosts, String proxyHost, int proxyPort, String proxyUsername, String proxyPassword) {
+        r.configure(form -> {
+            form.getInputByName("_.clientConfiguration").setChecked(true);
+            form.getInputByName("_.nonProxyHosts").setValue(nonProxyHosts);
+            form.getInputByName("_.proxyHost").setValue(proxyHost);
+            form.getInputByName("_.proxyPort").setValue(String.valueOf(proxyPort));
+            form.getInputByName("_.proxyUsername").setValue(proxyUsername);
+            form.getInputByName("_.proxyPassword").setValue(proxyPassword);
+        });
+    }
+}

--- a/src/test/resources/config/client/clientConfiguration.yml
+++ b/src/test/resources/config/client/clientConfiguration.yml
@@ -1,0 +1,9 @@
+unclassified:
+  awsCredentialsProvider:
+    client:
+      clientConfiguration:
+        nonProxyHosts: "example.com"
+        proxyHost: "localhost"
+        proxyPort: 5000
+        proxyUsername: "user"
+        proxyPassword: "fake"


### PR DESCRIPTION
Link to issue: https://github.com/jenkinsci/aws-secrets-manager-credentials-provider-plugin/issues/305

Jenkins url/manage/pluginManager/advanced gives the user the option to specify Http Proxy Configuration.

This configuration is not used by the aws-secrets-manager-credentials-provider-plugin. 

With this pull request I propose that the plugin uses the proxy configuration if it is provided.

### Testing done

**Configuration**
![image](https://github.com/jenkinsci/aws-secrets-manager-credentials-provider-plugin/assets/2352273/89bb60a5-5438-46bf-b99c-5c134a2cc3bd)

**AWS credentials are not listed**
![image](https://github.com/jenkinsci/aws-secrets-manager-credentials-provider-plugin/assets/2352273/34f29cc8-d378-4869-997c-9808afa9b11b)

**The error in the logs**
![image](https://github.com/jenkinsci/aws-secrets-manager-credentials-provider-plugin/assets/2352273/13a8a9de-06c7-4b97-a87b-fa813defd4e6)

**After installing the local build the AWS creds are listed**
![image](https://github.com/jenkinsci/aws-secrets-manager-credentials-provider-plugin/assets/2352273/c0674145-26b7-4b7d-8e30-fbd2faf797d7)

**Testing with the proxy not set**

![image](https://github.com/jenkinsci/aws-secrets-manager-credentials-provider-plugin/assets/2352273/5dd30527-828c-4cb0-b92a-c79a810083ef)

![image](https://github.com/jenkinsci/aws-secrets-manager-credentials-provider-plugin/assets/2352273/db0a789f-d879-443c-b927-a919433473f7)


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
